### PR TITLE
Store hooks using store_metadata

### DIFF
--- a/mui/mui.py
+++ b/mui/mui.py
@@ -37,10 +37,11 @@ from mui.manticore_native_runner import ManticoreNativeRunner
 from mui.native_hooks import NativeHooks, NativeHookType
 from mui.notification import UINotification
 from mui.settings import MUISettings
-from mui.utils import highlight_instr, clear_highlight, get_mgr
+from mui.utils import highlight_instr, clear_highlight
 
 settings = Settings()
 
+BinaryView.set_default_session_data("mui_hooks", None)
 BinaryView.set_default_session_data("mui_is_running", False)
 BinaryView.set_default_session_data("mui_state", None)
 BinaryView.set_default_session_data("mui_evm_source", None)
@@ -53,7 +54,7 @@ def find_instr(bv: BinaryView, addr: int):
     # Highlight the instruction in green
     highlight_instr(bv, addr, HighlightStandardColor.GreenHighlightColor)
 
-    hooks = get_mgr(bv).hooks
+    hooks = bv.session_data.hooks
     hooks.add_hook(NativeHookType.FIND, addr)
 
 
@@ -63,7 +64,7 @@ def rm_find_instr(bv: BinaryView, addr: int):
     # Remove instruction highlight
     clear_highlight(bv, addr)
 
-    hooks = get_mgr(bv).hooks
+    hooks = bv.session_data.hooks
     hooks.del_hook(NativeHookType.FIND, addr)
 
 
@@ -73,7 +74,7 @@ def avoid_instr(bv: BinaryView, addr: int):
     # Highlight the instruction in red
     highlight_instr(bv, addr, HighlightStandardColor.RedHighlightColor)
 
-    hooks = get_mgr(bv).hooks
+    hooks = bv.session_data.hooks
     hooks.add_hook(NativeHookType.AVOID, addr)
 
 
@@ -83,7 +84,7 @@ def rm_avoid_instr(bv: BinaryView, addr: int):
     # Remove instruction highlight
     clear_highlight(bv, addr)
 
-    hooks = get_mgr(bv).hooks
+    hooks = bv.session_data.hooks
     hooks.del_hook(NativeHookType.AVOID, addr)
 
 
@@ -124,7 +125,7 @@ def solve(bv: BinaryView):
             s.start()
 
     else:
-        hooks = get_mgr(bv).hooks
+        hooks = bv.session_data.hooks
         if len(hooks.find) == 0 and len(hooks.custom.keys()) == 0:
             show_message_box(
                 "Manticore Solve",
@@ -149,7 +150,7 @@ def solve(bv: BinaryView):
 
 def edit_custom_hook(bv: BinaryView, addr: int):
     dialog = CodeDialog(DockHandler.getActiveDockHandler().parent(), bv)
-    hooks = get_mgr(bv).hooks
+    hooks = bv.session_data.hooks
 
     if addr in hooks.custom:
         dialog.set_text(hooks.custom[addr])
@@ -210,13 +211,13 @@ def stop_manticore(bv: BinaryView):
 
 def avoid_instr_is_valid(bv: BinaryView, addr: int):
     """checks if avoid_instr is valid for a given address"""
-    hooks = get_mgr(bv).hooks
+    hooks = bv.session_data.hooks
     return not hooks.has_hook(NativeHookType.AVOID, addr)
 
 
 def find_instr_is_valid(bv: BinaryView, addr: int):
     """checks if find_instr is valid for a given address"""
-    hooks = get_mgr(bv).hooks
+    hooks = bv.session_data.hooks
     return not hooks.has_hook(NativeHookType.FIND, addr)
 
 

--- a/mui/mui.py
+++ b/mui/mui.py
@@ -48,39 +48,6 @@ BinaryView.set_default_session_data("mui_state", None)
 BinaryView.set_default_session_data("mui_evm_source", None)
 BinaryView.set_default_session_data("mui_addr_offset", None)
 
-
-def offset_address(bv: BinaryView, addr: int):
-    """Offsets addresses to take into consideration position independent executables (PIE)"""
-    # Addresses taken from https://github.com/trailofbits/manticore/blob/c3eabe03cf94f410bedd96d850df09cb0bda1711/manticore/platforms/linux.py#L954-L956
-    BASE_DYN_ADDR = 0x555555554000
-    BASE_DYN_ADDR_32 = 0x56555000
-
-    addr_off = bv.session_data.mui_addr_offset
-    if addr_off == None:
-        if bv.arch == Architecture["x86_64"]:
-            h_addr = bv.symbols["__elf_header"][0].address
-            h_type = bv.types["Elf64_Header"]
-            header = TypedDataAccessor(h_type, h_addr, bv, Endianness.LittleEndian)
-            if header["type"].value == 3:  # ET_DYN
-                addr_off = BASE_DYN_ADDR
-            else:
-                addr_off = 0
-        elif bv.arch == Architecture["x86"]:
-            h_addr = bv.symbols["__elf_header"][0].address
-            h_type = bv.types["Elf32_Header"]
-            header = TypedDataAccessor(h_type, h_addr, bv, Endianness.LittleEndian)
-            if header["type"].value == 3:  # ET_DYN
-                addr_off = BASE_DYN_ADDR_32
-            else:
-                addr_off = 0
-        else:
-            addr_off = 0
-
-        bv.session_data.mui_addr_offset = addr_off
-
-    return addr_off + addr
-
-
 def find_instr(bv: BinaryView, addr: int):
     """This command handler adds a given address to the find list and highlights it green in the UI"""
 
@@ -88,7 +55,7 @@ def find_instr(bv: BinaryView, addr: int):
     highlight_instr(bv, addr, HighlightStandardColor.GreenHighlightColor)
 
     # Add the instruction to the list associated with the current view
-    bv.session_data.mui_find.add(offset_address(bv, addr))
+    bv.session_data.mui_find.add(addr)
 
 
 def rm_find_instr(bv: BinaryView, addr: int):
@@ -98,7 +65,7 @@ def rm_find_instr(bv: BinaryView, addr: int):
     clear_highlight(bv, addr)
 
     # Remove the instruction to the list associated with the current view
-    bv.session_data.mui_find.remove(offset_address(bv, addr))
+    bv.session_data.mui_find.remove(addr)
 
 
 def avoid_instr(bv: BinaryView, addr: int):
@@ -108,7 +75,7 @@ def avoid_instr(bv: BinaryView, addr: int):
     highlight_instr(bv, addr, HighlightStandardColor.RedHighlightColor)
 
     # Add the instruction to the list associated with the current view
-    bv.session_data.mui_avoid.add(offset_address(bv, addr))
+    bv.session_data.mui_avoid.add(addr)
 
 
 def rm_avoid_instr(bv: BinaryView, addr: int):
@@ -118,7 +85,7 @@ def rm_avoid_instr(bv: BinaryView, addr: int):
     clear_highlight(bv, addr)
 
     # Remove the instruction to the list associated with the current view
-    bv.session_data.mui_avoid.remove(offset_address(bv, addr))
+    bv.session_data.mui_avoid.remove(addr)
 
 
 def solve(bv: BinaryView):
@@ -183,10 +150,8 @@ def solve(bv: BinaryView):
 def edit_custom_hook(bv: BinaryView, addr: int):
     dialog = CodeDialog(DockHandler.getActiveDockHandler().parent(), bv)
 
-    off_addr = offset_address(bv, addr)
-
-    if off_addr in bv.session_data.mui_custom_hooks:
-        dialog.set_text(bv.session_data.mui_custom_hooks[off_addr])
+    if addr in bv.session_data.mui_custom_hooks:
+        dialog.set_text(bv.session_data.mui_custom_hooks[addr])
 
     result: QDialog.DialogCode = dialog.exec()
 
@@ -194,14 +159,14 @@ def edit_custom_hook(bv: BinaryView, addr: int):
 
         if len(dialog.text()) == 0:
             # delete the hook if empty input is provided
-            if off_addr in bv.session_data.mui_custom_hooks:
+            if addr in bv.session_data.mui_custom_hooks:
                 clear_highlight(bv, addr)
-                del bv.session_data.mui_custom_hooks[off_addr]
+                del bv.session_data.mui_custom_hooks[addr]
 
         else:
             # add/edit the hook if input is non-empty
             highlight_instr(bv, addr, HighlightStandardColor.BlueHighlightColor)
-            bv.session_data.mui_custom_hooks[off_addr] = dialog.text()
+            bv.session_data.mui_custom_hooks[addr] = dialog.text()
 
 
 def load_evm(bv: BinaryView):
@@ -245,12 +210,12 @@ def stop_manticore(bv: BinaryView):
 
 def avoid_instr_is_valid(bv: BinaryView, addr: int):
     """checks if avoid_instr is valid for a given address"""
-    return offset_address(bv, addr) not in bv.session_data.mui_avoid
+    return addr not in bv.session_data.mui_avoid
 
 
 def find_instr_is_valid(bv: BinaryView, addr: int):
     """checks if find_instr is valid for a given address"""
-    return offset_address(bv, addr) not in bv.session_data.mui_find
+    return addr not in bv.session_data.mui_find
 
 
 def solve_is_valid(bv: BinaryView):

--- a/mui/native_hooks.py
+++ b/mui/native_hooks.py
@@ -1,0 +1,71 @@
+from enum import Enum
+from xmlrpc.client import Boolean
+from binaryninja import BinaryView
+
+
+class NativeHookType(Enum):
+    FIND = 0
+    AVOID = 1
+    CUSTOM = 2
+
+
+class NativeHooks:
+    """Class to manage native hooks"""
+
+    def __init__(self, bv: BinaryView) -> None:
+        self.bv = bv
+        self.deserialise_metadata()
+        pass
+
+    def add_hook(self, hook_type: NativeHookType, addr: int, code: str = "") -> None:
+        if hook_type == NativeHookType.FIND:
+            self.find.add(addr)
+        elif hook_type == NativeHookType.AVOID:
+            self.avoid.add(addr)
+        elif hook_type == NativeHookType.CUSTOM:
+            self.custom[addr] = code
+        else:
+            raise Exception("Added hook of invalid type")
+
+    def del_hook(self, hook_type: NativeHookType, addr: int) -> None:
+        if hook_type == NativeHookType.FIND:
+            self.find.remove(addr)
+        elif hook_type == NativeHookType.AVOID:
+            self.avoid.remove(addr)
+        elif hook_type == NativeHookType.CUSTOM:
+            if addr in self.custom:
+                del self.custom[addr]
+        else:
+            raise Exception("Deleting hook of invalid type")
+
+    def has_hook(self, hook_type: NativeHookType, addr: int) -> Boolean:
+        if hook_type == NativeHookType.FIND:
+            return addr in self.find
+        elif hook_type == NativeHookType.AVOID:
+            return addr in self.avoid
+        elif hook_type == NativeHookType.CUSTOM:
+            return addr in self.custom
+        else:
+            raise Exception("Searching for hook of invalid type")
+
+    def serialise_metadata(self) -> None:
+        bv = self.bv
+        bv.store_metadata("mui.hooks.find", list(self.find))
+        bv.store_metadata("mui.hooks.avoid", list(self.avoid))
+        bv.store_metadata("mui.hooks.custom", self.custom)
+
+    def deserialise_metadata(self) -> None:
+        bv = self.bv
+
+        def get_metadata(key, default):
+            try:
+                return bv.query_metadata(key)
+            except KeyError:
+                return default
+
+        self.find = set(get_metadata("mui.hooks.find", []))
+        self.avoid = set(get_metadata("mui.hooks.avoid", []))
+        custom = get_metadata("mui.hooks.custom", dict())
+        self.custom = dict()
+        for addr in custom.keys():
+            self.custom[int(addr)] = custom[addr]

--- a/mui/notification.py
+++ b/mui/notification.py
@@ -4,7 +4,8 @@ from binaryninja import BinaryView, FileMetadata, Settings, HighlightStandardCol
 from binaryninjaui import UIContextNotification, UIContext, FileContext, ViewFrame
 
 from mui.constants import BINJA_HOOK_SETTINGS_PREFIX
-from mui.utils import highlight_instr, get_mgr
+from mui.utils import highlight_instr
+from mui.native_hooks import NativeHooks
 
 
 class UINotification(UIContextNotification):
@@ -24,15 +25,16 @@ class UINotification(UIContextNotification):
 
         bv: BinaryView = frame.getCurrentBinaryView()
 
-        # Initialise manager
-        mgr = get_mgr(bv)
+        # Initialise hooks
+        hooks = NativeHooks(bv)
+        bv.session_data.hooks = hooks
 
         # restore highlight
-        for addr in mgr.hooks.find:
+        for addr in hooks.find:
             highlight_instr(bv, addr, HighlightStandardColor.GreenHighlightColor)
-        for addr in mgr.hooks.avoid:
+        for addr in hooks.avoid:
             highlight_instr(bv, addr, HighlightStandardColor.RedHighlightColor)
-        for addr in mgr.hooks.custom.keys():
+        for addr in hooks.custom.keys():
             highlight_instr(bv, addr, HighlightStandardColor.BlueHighlightColor)
 
     def OnBeforeSaveFile(self, context: UIContext, file: FileContext, frame: ViewFrame) -> bool:
@@ -41,7 +43,6 @@ class UINotification(UIContextNotification):
         bv: BinaryView = frame.getCurrentBinaryView()
 
         # Save to bndb
-        hooks = get_mgr(bv).hooks
-        hooks.serialise_metadata()
+        bv.session_data.hooks.serialise_metadata()
 
         return True

--- a/mui/utils.py
+++ b/mui/utils.py
@@ -15,36 +15,37 @@ from binaryninja import (
 from manticore.core.plugin import StateDescriptor
 
 
+class MUIManager:
+    """Class that manages data/state for each instance of MUI created"""
+
+    def __init__(self, bv: BinaryView):
+        self.bv = bv
+        self.hooks = NativeHooks(bv)
+
+
+managers: typing.List[MUIManager] = []
+
+
 def get_mgr(bv: BinaryView):
     """Get the manager for the bv instance"""
-    for mgr in MUIManager.managers:
+    for mgr in managers:
         if mgr.bv == bv:
             return mgr
 
     mgr = MUIManager(bv)
-    MUIManager.managers.append(mgr)
+    managers.append(mgr)
     return mgr
 
 
 def del_mgr(bv: BinaryView):
     """Delete manager"""
     mgr = None
-    for _mgr in MUIManager.managers:
+    for _mgr in managers:
         if _mgr.bv == bv:
             mgr = _mgr
 
     if mgr:
-        MUIManager.managers.remove(mgr)
-
-
-class MUIManager:
-    """Class that manages data/state for each instance of MUI created"""
-
-    managers = []
-
-    def __init__(self, bv: BinaryView):
-        self.bv = bv
-        self.hooks = NativeHooks(bv)
+        managers.remove(mgr)
 
 
 class MUIState:

--- a/mui/utils.py
+++ b/mui/utils.py
@@ -2,6 +2,7 @@ import os
 import typing
 from pathlib import Path
 from datetime import datetime
+from mui.native_hooks import NativeHooks
 
 from binaryninja import (
     BinaryView,
@@ -12,6 +13,38 @@ from binaryninja import (
     HighlightColor,
 )
 from manticore.core.plugin import StateDescriptor
+
+
+def get_mgr(bv: BinaryView):
+    """Get the manager for the bv instance"""
+    for mgr in MUIManager.managers:
+        if mgr.bv == bv:
+            return mgr
+
+    mgr = MUIManager(bv)
+    MUIManager.managers.append(mgr)
+    return mgr
+
+
+def del_mgr(bv: BinaryView):
+    """Delete manager"""
+    mgr = None
+    for _mgr in MUIManager.managers:
+        if _mgr.bv == bv:
+            mgr = _mgr
+
+    if mgr:
+        MUIManager.managers.remove(mgr)
+
+
+class MUIManager:
+    """Class that manages data/state for each instance of MUI created"""
+
+    managers = []
+
+    def __init__(self, bv: BinaryView):
+        self.bv = bv
+        self.hooks = NativeHooks(bv)
 
 
 class MUIState:

--- a/mui/utils.py
+++ b/mui/utils.py
@@ -15,39 +15,6 @@ from binaryninja import (
 from manticore.core.plugin import StateDescriptor
 
 
-class MUIManager:
-    """Class that manages data/state for each instance of MUI created"""
-
-    def __init__(self, bv: BinaryView):
-        self.bv = bv
-        self.hooks = NativeHooks(bv)
-
-
-managers: typing.List[MUIManager] = []
-
-
-def get_mgr(bv: BinaryView):
-    """Get the manager for the bv instance"""
-    for mgr in managers:
-        if mgr.bv == bv:
-            return mgr
-
-    mgr = MUIManager(bv)
-    managers.append(mgr)
-    return mgr
-
-
-def del_mgr(bv: BinaryView):
-    """Delete manager"""
-    mgr = None
-    for _mgr in managers:
-        if _mgr.bv == bv:
-            mgr = _mgr
-
-    if mgr:
-        managers.remove(mgr)
-
-
 class MUIState:
     def __init__(self, bv: BinaryView):
         self.bv = bv


### PR DESCRIPTION
Refactored the code to change persistence method.
Currently, we use `bv.session_data.*` to store the hooks impermanently, and then it is stored and retrieved from the bndb settings in order to be persistent across sessions.
This PR uses the `bv.store_metadata` to store the hooks permanently in the bndb upon save, and retrieve from the bndb upon open.

I also moved the code handling PIE binaries to the `native_runner` code to make the code cleaner.