### PR TITLE
Add binary ninja plugin manager metadata

### DIFF
--- a/binjastub/README.md
+++ b/binjastub/README.md
@@ -1,0 +1,7 @@
+# ManticoreUI (MUI)
+
+![Manticore logo](https://raw.githubusercontent.com/trailofbits/manticore/master/docs/images/manticore.png)
+
+With the Manticore User Interface (MUI) project, we provide a graphical user interface plugin for Binary Ninja to allow users to easily interact with and view progress of the [Manticore symbolic execution engine](https://github.com/trailofbits/manticore) for analysis of smart contracts and native binaries.
+
+❗ATTENTION❗ This project is under active development and may be unstable or unusable. Please [open an issue](https://github.com/trailofbits/ManticoreUI/issues) if you have any difficulties using the existing features. New feature development will be considered on a case by case basis.

--- a/binjastub/__init__.py
+++ b/binjastub/__init__.py
@@ -1,0 +1,1 @@
+import mui

--- a/binjastub/plugin.json
+++ b/binjastub/plugin.json
@@ -1,0 +1,24 @@
+{
+   "pluginmetadataversion": 2,
+   "name": "ManticoreUI",
+   "author": "Trail of Bits",
+   "type": [
+      "ui",
+      "helper"
+   ],
+   "api": [
+      "python3"
+   ],
+   "description": "Graphical user interface to interact with Manticore symbolic execution engine",
+   "longdescription": "",
+   "license": {
+      "name": "AGPL-3.0",
+      "text": "Copyright (C) 2022  Trail of Bits\n\nThis program is free software: you can redistribute it and/or modify\nit under the terms of the GNU Affero General Public License as\npublished by the Free Software Foundation, either version 3 of the\nLicense, or (at your option) any later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU Affero General Public License for more details.\n\nYou should have received a copy of the GNU Affero General Public License\nalong with this program.  If not, see <https://www.gnu.org/licenses/>."
+   },
+   "platforms": [
+      "Darwin",
+      "Linux"
+   ],
+   "version": "v0.1.0",
+   "minimumbinaryninjaversion": 2901
+}

--- a/binjastub/requirements.txt
+++ b/binjastub/requirements.txt
@@ -1,3 +1,3 @@
-git+git://github.com/trailofbits/manticore.git@0.3.7
+git+git://github.com/trailofbits/manticore.git@a16a01148bde965803cc3a2101bf4e03b0dfe340
 pygments>=2.7.0,<2.9.0
 crytic-compile>=0.2.0

--- a/binjastub/requirements.txt
+++ b/binjastub/requirements.txt
@@ -1,0 +1,3 @@
+git+git://github.com/trailofbits/manticore.git@0.3.7
+pygments>=2.7.0,<2.9.0
+crytic-compile>=0.2.0


### PR DESCRIPTION
Closes https://github.com/trailofbits/ManticoreUI/issues/16

I've added the metadata necessary to submit to the community-plugins repository.

![image](https://user-images.githubusercontent.com/18577367/157433156-bc1067a9-fbad-4b83-8e78-6c21bb2aefde.png)
Preview `s/idiot/community/g` because it's on my test repo.

However there is a small blocking issue, the requirements in `binjastub/requirements.txt` will get properly installed except for `z3` (when using virtual environments, not tested without virtualenv yet). The issue is that the way binary ninja plugin manager installs dependencies straight to the virtual environment using the `--target` flag, which does not update the `venv/bin` with `z3`. When z3 is installed as a library but not in the bin, manticore does not detect that z3 exists, because it uses `which` to detect for z3.

**Possible fixes**:
- Just ask users to install dependencies separately on commandline (simple `pip install -r requirements.txt`)
- Somehow figure out how to install with bins using binary ninja plugin manager