### PR TITLE
Add hook list widget

### DIFF
--- a/mui/dockwidgets/hook_list_widget.py
+++ b/mui/dockwidgets/hook_list_widget.py
@@ -1,0 +1,85 @@
+from time import sleep
+from enum import Enum
+from typing import Dict, Final, Optional, Tuple
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QTreeWidgetItem, QTreeWidget
+from binaryninja import BinaryView, BinaryViewEvent, BinaryViewEventType, BinaryViewType
+from binaryninjaui import DockContextHandler, ViewFrame
+
+class HookType(Enum):
+    FIND = 0
+    AVOID = 1
+    CUSTOM = 2
+
+class HookListWidget(QWidget, DockContextHandler):
+
+    NAME: Final[str] = "Manticore Hooks"
+
+    # column used for hook address
+    HOOK_ADDR_COLUMN: Final[int] = 0
+
+    HOOK_ROLE: Final[int] = Qt.UserRole
+
+    def __init__(self, name: str, parent: ViewFrame, data: BinaryView):
+        QWidget.__init__(self, parent)
+        DockContextHandler.__init__(self, self, name)
+
+        self.bv = data
+
+        tree_widget = QTreeWidget()
+        tree_widget.setColumnCount(1)
+        tree_widget.headerItem().setText(0, "Hook List")
+        self.tree_widget = tree_widget
+
+        self.find_hooks = QTreeWidgetItem(None, ["Find"])
+        self.avoid_hooks = QTreeWidgetItem(None, ["Avoid"])
+        self.custom_hooks = QTreeWidgetItem(None, ["Custom"])
+
+        self.hook_lists = [
+            self.find_hooks,
+            self.avoid_hooks,
+            self.custom_hooks,
+        ]
+
+        tree_widget.insertTopLevelItems(0, self.hook_lists)
+        for hook_list in self.hook_lists:
+            tree_widget.expandItem(hook_list)
+
+        layout = QVBoxLayout()
+        layout.addWidget(tree_widget)
+        self.setLayout(layout)
+
+        self.hook_items : Dict[Tuple[HookType, int], QTreeWidgetItem] = {}
+    
+    def add_hook(self, hook_type: HookType, addr: int):
+        """Add a hook to its corresponding hook list"""
+        parent = None
+        if hook_type == HookType.FIND:
+            parent = self.find_hooks
+        elif hook_type == HookType.AVOID:
+            parent = self.avoid_hooks
+        elif hook_type == HookType.CUSTOM:
+            parent = self.custom_hooks
+        else:
+            raise Exception('Invalid hook type') 
+        
+        item = QTreeWidgetItem(parent, [f"{addr:08x}"])
+        item.setData(self.HOOK_ADDR_COLUMN, self.HOOK_ROLE, addr)
+        self.hook_items[(hook_type, addr)] = item
+    
+    def remove_hook(self, hook_type: HookType, addr: int):
+        """Remove a hook from its corresponding hook list"""
+        item = self.hook_items[(hook_type, addr)]
+        item.parent().removeChild(item)
+    
+    def _load_existing_hooks(self):
+        """Load existing hooks from session data"""
+        for addr in self.bv.session_data.mui_find:
+            self.add_hook(HookType.FIND, addr)
+
+        for addr in self.bv.session_data.mui_avoid:
+            self.add_hook(HookType.AVOID, addr)
+
+        for addr in self.bv.session_data.mui_custom_hooks.keys():
+            self.add_hook(HookType.CUSTOM, addr)

--- a/mui/manticore_native_runner.py
+++ b/mui/manticore_native_runner.py
@@ -2,7 +2,14 @@ import tempfile
 from time import sleep
 from typing import Callable, Set
 
-from binaryninja import BackgroundTaskThread, Settings, BinaryView, TypedDataAccessor, Endianness, Architecture
+from binaryninja import (
+    BackgroundTaskThread,
+    Settings,
+    BinaryView,
+    TypedDataAccessor,
+    Endianness,
+    Architecture,
+)
 from manticore.core.state import StateBase
 from manticore.native import Manticore
 
@@ -20,9 +27,12 @@ class ManticoreNativeRunner(BackgroundTaskThread):
 
         # Get binary base (if necessary) and rebase hooks
         self.addr_off = self.get_address_offset(view)
-        self.find = [addr+self.addr_off for addr in find]
-        self.avoid = [addr+self.addr_off for addr in avoid]
-        self.custom_hooks = [(addr+self.addr_off, func) for addr, func in view.session_data.mui_custom_hooks.items()]
+        self.find = [addr + self.addr_off for addr in find]
+        self.avoid = [addr + self.addr_off for addr in avoid]
+        self.custom_hooks = [
+            (addr + self.addr_off, func)
+            for addr, func in view.session_data.mui_custom_hooks.items()
+        ]
 
         # Write the binary to disk so that the Manticore API can read it
         self.binary = tempfile.NamedTemporaryFile()
@@ -135,7 +145,7 @@ class ManticoreNativeRunner(BackgroundTaskThread):
                     print_timestamp("Manticore finished without reaching find")
         finally:
             bv.session_data.mui_is_running = False
-    
+
     def get_address_offset(self, bv: BinaryView):
         """Offsets addresses to take into consideration position independent executables (PIE)"""
         # Addresses taken from https://github.com/trailofbits/manticore/blob/c3eabe03cf94f410bedd96d850df09cb0bda1711/manticore/platforms/linux.py#L954-L956

--- a/mui/mui.py
+++ b/mui/mui.py
@@ -48,39 +48,6 @@ BinaryView.set_default_session_data("mui_state", None)
 BinaryView.set_default_session_data("mui_evm_source", None)
 BinaryView.set_default_session_data("mui_addr_offset", None)
 
-
-def offset_address(bv: BinaryView, addr: int):
-    """Offsets addresses to take into consideration position independent executables (PIE)"""
-    # Addresses taken from https://github.com/trailofbits/manticore/blob/c3eabe03cf94f410bedd96d850df09cb0bda1711/manticore/platforms/linux.py#L954-L956
-    BASE_DYN_ADDR = 0x555555554000
-    BASE_DYN_ADDR_32 = 0x56555000
-
-    addr_off = bv.session_data.mui_addr_offset
-    if addr_off == None:
-        if bv.arch == Architecture["x86_64"]:
-            h_addr = bv.symbols["__elf_header"][0].address
-            h_type = bv.types["Elf64_Header"]
-            header = TypedDataAccessor(h_type, h_addr, bv, Endianness.LittleEndian)
-            if header["type"].value == 3:  # ET_DYN
-                addr_off = BASE_DYN_ADDR
-            else:
-                addr_off = 0
-        elif bv.arch == Architecture["x86"]:
-            h_addr = bv.symbols["__elf_header"][0].address
-            h_type = bv.types["Elf32_Header"]
-            header = TypedDataAccessor(h_type, h_addr, bv, Endianness.LittleEndian)
-            if header["type"].value == 3:  # ET_DYN
-                addr_off = BASE_DYN_ADDR_32
-            else:
-                addr_off = 0
-        else:
-            addr_off = 0
-
-        bv.session_data.mui_addr_offset = addr_off
-
-    return addr_off + addr
-
-
 def find_instr(bv: BinaryView, addr: int):
     """This command handler adds a given address to the find list and highlights it green in the UI"""
 
@@ -88,7 +55,7 @@ def find_instr(bv: BinaryView, addr: int):
     highlight_instr(bv, addr, HighlightStandardColor.GreenHighlightColor)
 
     # Add the instruction to the list associated with the current view
-    bv.session_data.mui_find.add(offset_address(bv, addr))
+    bv.session_data.mui_find.add(addr)
 
 
 def rm_find_instr(bv: BinaryView, addr: int):
@@ -98,7 +65,7 @@ def rm_find_instr(bv: BinaryView, addr: int):
     clear_highlight(bv, addr)
 
     # Remove the instruction to the list associated with the current view
-    bv.session_data.mui_find.remove(offset_address(bv, addr))
+    bv.session_data.mui_find.remove(addr)
 
 
 def avoid_instr(bv: BinaryView, addr: int):
@@ -108,7 +75,7 @@ def avoid_instr(bv: BinaryView, addr: int):
     highlight_instr(bv, addr, HighlightStandardColor.RedHighlightColor)
 
     # Add the instruction to the list associated with the current view
-    bv.session_data.mui_avoid.add(offset_address(bv, addr))
+    bv.session_data.mui_avoid.add(addr)
 
 
 def rm_avoid_instr(bv: BinaryView, addr: int):
@@ -118,7 +85,7 @@ def rm_avoid_instr(bv: BinaryView, addr: int):
     clear_highlight(bv, addr)
 
     # Remove the instruction to the list associated with the current view
-    bv.session_data.mui_avoid.remove(offset_address(bv, addr))
+    bv.session_data.mui_avoid.remove(addr)
 
 
 def solve(bv: BinaryView):
@@ -183,10 +150,8 @@ def solve(bv: BinaryView):
 def edit_custom_hook(bv: BinaryView, addr: int):
     dialog = CodeDialog(DockHandler.getActiveDockHandler().parent(), bv)
 
-    off_addr = offset_address(bv, addr)
-
-    if off_addr in bv.session_data.mui_custom_hooks:
-        dialog.set_text(bv.session_data.mui_custom_hooks[off_addr])
+    if addr in bv.session_data.mui_custom_hooks:
+        dialog.set_text(bv.session_data.mui_custom_hooks[addr])
 
     result: QDialog.DialogCode = dialog.exec()
 
@@ -194,14 +159,14 @@ def edit_custom_hook(bv: BinaryView, addr: int):
 
         if len(dialog.text()) == 0:
             # delete the hook if empty input is provided
-            if off_addr in bv.session_data.mui_custom_hooks:
+            if addr in bv.session_data.mui_custom_hooks:
                 clear_highlight(bv, addr)
-                del bv.session_data.mui_custom_hooks[off_addr]
+                del bv.session_data.mui_custom_hooks[addr]
 
         else:
             # add/edit the hook if input is non-empty
             highlight_instr(bv, addr, HighlightStandardColor.BlueHighlightColor)
-            bv.session_data.mui_custom_hooks[off_addr] = dialog.text()
+            bv.session_data.mui_custom_hooks[addr] = dialog.text()
 
 
 def load_evm(bv: BinaryView):
@@ -245,12 +210,12 @@ def stop_manticore(bv: BinaryView):
 
 def avoid_instr_is_valid(bv: BinaryView, addr: int):
     """checks if avoid_instr is valid for a given address"""
-    return offset_address(bv, addr) not in bv.session_data.mui_avoid
+    return addr not in bv.session_data.mui_avoid
 
 
 def find_instr_is_valid(bv: BinaryView, addr: int):
     """checks if find_instr is valid for a given address"""
-    return offset_address(bv, addr) not in bv.session_data.mui_find
+    return addr not in bv.session_data.mui_find
 
 
 def solve_is_valid(bv: BinaryView):

--- a/mui/mui.py
+++ b/mui/mui.py
@@ -47,6 +47,7 @@ BinaryView.set_default_session_data("mui_state", None)
 BinaryView.set_default_session_data("mui_evm_source", None)
 BinaryView.set_default_session_data("mui_addr_offset", None)
 
+
 def find_instr(bv: BinaryView, addr: int):
     """This command handler adds a given address to the find list and highlights it green in the UI"""
 
@@ -57,7 +58,7 @@ def find_instr(bv: BinaryView, addr: int):
     bv.session_data.mui_find.add(addr)
 
     # Add to hook list widget
-    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME) 
+    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
     hook_widget.add_hook(HookType.FIND, addr)
 
 
@@ -71,7 +72,7 @@ def rm_find_instr(bv: BinaryView, addr: int):
     bv.session_data.mui_find.remove(addr)
 
     # Remove from hook list widget
-    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME) 
+    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
     hook_widget.remove_hook(HookType.FIND, addr)
 
 
@@ -85,7 +86,7 @@ def avoid_instr(bv: BinaryView, addr: int):
     bv.session_data.mui_avoid.add(addr)
 
     # Add to hook list widget
-    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME) 
+    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
     hook_widget.add_hook(HookType.AVOID, addr)
 
 
@@ -99,7 +100,7 @@ def rm_avoid_instr(bv: BinaryView, addr: int):
     bv.session_data.mui_avoid.remove(addr)
 
     # Remove from hook list widget
-    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME) 
+    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
     hook_widget.remove_hook(HookType.AVOID, addr)
 
 
@@ -164,6 +165,7 @@ def solve(bv: BinaryView):
 
 def edit_custom_hook(bv: BinaryView, addr: int):
     dialog = CodeDialog(DockHandler.getActiveDockHandler().parent(), bv)
+    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
 
     if addr in bv.session_data.mui_custom_hooks:
         dialog.set_text(bv.session_data.mui_custom_hooks[addr])
@@ -177,10 +179,14 @@ def edit_custom_hook(bv: BinaryView, addr: int):
             if addr in bv.session_data.mui_custom_hooks:
                 clear_highlight(bv, addr)
                 del bv.session_data.mui_custom_hooks[addr]
+                hook_widget.remove_hook(HookType.CUSTOM, addr)
 
         else:
             # add/edit the hook if input is non-empty
             highlight_instr(bv, addr, HighlightStandardColor.BlueHighlightColor)
+            # add to hook list if new
+            if addr not in bv.session_data.mui_custom_hooks:
+                hook_widget.add_hook(HookType.CUSTOM, addr)
             bv.session_data.mui_custom_hooks[addr] = dialog.text()
 
 

--- a/mui/mui.py
+++ b/mui/mui.py
@@ -17,8 +17,6 @@ from binaryninja import (
     get_open_filename_input,
     Architecture,
     SettingsScope,
-    TypedDataAccessor,
-    Endianness,
 )
 from binaryninjaui import DockHandler, UIContext
 from crytic_compile import CryticCompile
@@ -32,6 +30,7 @@ from mui.dockwidgets.code_dialog import CodeDialog
 from mui.dockwidgets.run_dialog import RunDialog
 from mui.dockwidgets.state_graph_widget import StateGraphWidget
 from mui.dockwidgets.state_list_widget import StateListWidget
+from mui.dockwidgets.hook_list_widget import HookListWidget, HookType
 from mui.manticore_evm_runner import ManticoreEVMRunner
 from mui.manticore_native_runner import ManticoreNativeRunner
 from mui.notification import UINotification
@@ -57,6 +56,10 @@ def find_instr(bv: BinaryView, addr: int):
     # Add the instruction to the list associated with the current view
     bv.session_data.mui_find.add(addr)
 
+    # Add to hook list widget
+    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME) 
+    hook_widget.add_hook(HookType.FIND, addr)
+
 
 def rm_find_instr(bv: BinaryView, addr: int):
     """This command handler removes a given address from the find list and undoes the highlights"""
@@ -66,6 +69,10 @@ def rm_find_instr(bv: BinaryView, addr: int):
 
     # Remove the instruction to the list associated with the current view
     bv.session_data.mui_find.remove(addr)
+
+    # Remove from hook list widget
+    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME) 
+    hook_widget.remove_hook(HookType.FIND, addr)
 
 
 def avoid_instr(bv: BinaryView, addr: int):
@@ -77,6 +84,10 @@ def avoid_instr(bv: BinaryView, addr: int):
     # Add the instruction to the list associated with the current view
     bv.session_data.mui_avoid.add(addr)
 
+    # Add to hook list widget
+    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME) 
+    hook_widget.add_hook(HookType.AVOID, addr)
+
 
 def rm_avoid_instr(bv: BinaryView, addr: int):
     """This command handler removes a given address from the avoid list and undoes the highlights"""
@@ -86,6 +97,10 @@ def rm_avoid_instr(bv: BinaryView, addr: int):
 
     # Remove the instruction to the list associated with the current view
     bv.session_data.mui_avoid.remove(addr)
+
+    # Remove from hook list widget
+    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME) 
+    hook_widget.remove_hook(HookType.AVOID, addr)
 
 
 def solve(bv: BinaryView):
@@ -269,6 +284,10 @@ PluginCommand.register(
 
 widget.register_dockwidget(
     StateListWidget, StateListWidget.NAME, Qt.RightDockWidgetArea, Qt.Vertical, True
+)
+
+widget.register_dockwidget(
+    HookListWidget, HookListWidget.NAME, Qt.RightDockWidgetArea, Qt.Vertical, True
 )
 
 widget.register_dockwidget(

--- a/mui/notification.py
+++ b/mui/notification.py
@@ -5,6 +5,8 @@ from binaryninjaui import UIContextNotification, UIContext, FileContext, ViewFra
 
 from mui.constants import BINJA_HOOK_SETTINGS_PREFIX
 from mui.utils import highlight_instr
+from mui.dockwidgets.hook_list_widget import HookListWidget
+from mui.dockwidgets import widget
 
 
 class UINotification(UIContextNotification):
@@ -38,6 +40,10 @@ class UINotification(UIContextNotification):
                 settings.get_string(f"{BINJA_HOOK_SETTINGS_PREFIX}custom", bv)
             ).items()
         }
+
+        # initialise hook list widget
+        hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
+        hook_widget.load_existing_hooks()
 
         # restore highlight
         for addr in bv.session_data.mui_find:


### PR DESCRIPTION
Closes https://github.com/trailofbits/ManticoreUI/issues/40

![image](https://user-images.githubusercontent.com/18577367/157828426-9f15825f-5771-47f1-8797-c416b5ce07ec.png)

Currently functionality just lists the find/avoid/custom hooks, and double clicking navigates the user to the specific hook.

Relocating the PIE handling to the runner also fixes an issue with hooks not getting highlighted in PIE binaries.