### PR TITLE
pip install manticore with a non-deprecated git protocol

### DIFF
--- a/binjastub/requirements.txt
+++ b/binjastub/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/trailofbits/manticore.git@a16a01148bde965803cc3a2101bf4e03b0dfe340
+git+https://github.com/trailofbits/manticore.git@a16a01148bde965803cc3a2101bf4e03b0dfe340
 pygments>=2.7.0,<2.9.0
 crytic-compile>=0.2.0
 capstone @ git+https://github.com/aquynh/capstone.git@1766485c0c32419e9a17d6ad31f9e218ef4f018f#subdirectory=bindings/python

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 pytest>=6
-black==21.6b0
+black==22.3.0
 mypy==0.910


### PR DESCRIPTION
just a tiny fix - `git://` should no longer be used as of Jan 11 2022, see: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

PR just changes the protocol to `https://`

This error will be shown if `git://` is used:
```
  Cloning git://github.com/trailofbits/manticore.git (to revision a16a01148bde965803cc3a2101bf4e03b0dfe340) to /tmp/pip-req-build-0d7jvv1_
  Running command git clone -q git://github.com/trailofbits/manticore.git /tmp/pip-req-build-0d7jvv1_
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```