### PR TITLE
Add option to unicorn emulate until address

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,7 @@ All MUI features can be accessed through either the right-click context menu or 
 - Find Path to This Instruction / Remove Instruction from Find List
 - Avoid This Instruction / Remove Instruction from Avoid List
 - Add/Edit Custom Hook
+- Add/Edit Global Hook
 - Add Function Model
 - Solve With Manticore / Stop Manticore
 
@@ -103,6 +104,7 @@ And the following widgets are available:
 - Run Dialog
 
     The run dialog is shown when you invoke the ``Solve with Manticore`` command. It allows you to configure the various manticore options, and the changes will be saved to the ``bndb`` file. Some example configs include using a combination of ``LD_PRELOAD`` and ``LD_LIBRARY_PATH`` environment variables to run the binary with custom glibc.
+    The ``Emulate until address`` option allows you to use the Unicorn engine's emulation until a certain address, for significant execution speed-up.
 
 .. image:: ./screenshots/run_dialog.png
     :align: center

--- a/mui/manticore_native_runner.py
+++ b/mui/manticore_native_runner.py
@@ -1,6 +1,6 @@
 import tempfile
 from time import sleep
-from typing import Callable, Set
+from typing import Callable, Set, Optional
 
 from binaryninja import (
     BackgroundTaskThread,
@@ -87,6 +87,7 @@ class ManticoreNativeRunner(BackgroundTaskThread):
                 ):
                     state.platform.add_symbolic_file(file)
 
+            emulate_until: Optional[int]
             try:
                 emulate_until = int(
                     settings.get_string(f"{BINJA_NATIVE_RUN_SETTINGS_PREFIX}emulateUntil", bv), 16

--- a/mui/manticore_native_runner.py
+++ b/mui/manticore_native_runner.py
@@ -12,6 +12,7 @@ from binaryninja import (
 )
 from manticore.core.state import StateBase
 from manticore.native import Manticore
+from manticore.core.plugin import Plugin
 
 from mui.constants import BINJA_NATIVE_RUN_SETTINGS_PREFIX
 from mui.dockwidgets import widget
@@ -85,6 +86,18 @@ class ManticoreNativeRunner(BackgroundTaskThread):
                     f"{BINJA_NATIVE_RUN_SETTINGS_PREFIX}symbolicFiles", bv
                 ):
                     state.platform.add_symbolic_file(file)
+
+            try:
+                emulate_until = int(
+                    settings.get_string(f"{BINJA_NATIVE_RUN_SETTINGS_PREFIX}emulateUntil", bv), 16
+                )
+                emulate_until += self.addr_off
+            except:
+                emulate_until = None
+
+            if emulate_until:
+                print(f"Using Unicorn emulation until {emulate_until:#x}")
+                m.register_plugin(UnicornEmulatePlugin(emulate_until))
 
             def avoid_f(state: StateBase):
                 state.abandon()
@@ -177,3 +190,15 @@ class ManticoreNativeRunner(BackgroundTaskThread):
             addr_off = 0
 
         return addr_off
+
+
+class UnicornEmulatePlugin(Plugin):
+    """Manticore plugin to speed up emulation using unicorn until `start`"""
+
+    def __init__(self, start: int):
+        super().__init__()
+        self.start = start
+
+    def will_run_callback(self, ready_states):
+        for state in ready_states:
+            state.cpu.emulate_until(self.start)

--- a/mui/settings.py
+++ b/mui/settings.py
@@ -58,6 +58,15 @@ class MUISettings:
                 },
                 {},
             ),
+            "emulateUntil": (
+                {
+                    "title": "Emulate until address (in hex)",
+                    "description": "Emulate using unicorn until address is reached",
+                    "type": "string",
+                    "default": "",
+                },
+                {},
+            ),
             "workspaceURL": (
                 {
                     "title": "Workspace URL",


### PR DESCRIPTION
Adds native run option to use unicorn to emulate the binary until a certain address.
This significantly speeds up the startup time for manticore.

Preview:
![image](https://user-images.githubusercontent.com/18577367/162113472-93b1ef68-769c-4a7c-9eab-f0f4e13d2650.png)
