### PR TITLE
Add shared library MUI hook support

### DIFF
--- a/mui/dockwidgets/global_hook_dialog.py
+++ b/mui/dockwidgets/global_hook_dialog.py
@@ -13,9 +13,7 @@ from binaryninja import (
 )
 from binaryninjaui import UIContext, DockHandler
 
-from mui.dockwidgets import widget
 from mui.dockwidgets.code_dialog import CodeDialog
-from mui.dockwidgets.hook_list_widget import HookListWidget, HookType
 from mui.hook_manager import NativeHookManager
 
 

--- a/mui/dockwidgets/library_dialog.py
+++ b/mui/dockwidgets/library_dialog.py
@@ -23,7 +23,7 @@ from mui.constants import BINJA_NATIVE_RUN_SETTINGS_PREFIX
 class LibraryDialog(QDialog):
     def __init__(self, parent: QWidget, data: BinaryView):
         self.bv = data
-        self.items = frozenset()
+        self.items: frozenset = frozenset()
 
         QDialog.__init__(self, parent)
 

--- a/mui/dockwidgets/library_dialog.py
+++ b/mui/dockwidgets/library_dialog.py
@@ -1,5 +1,5 @@
 import json
-from PySide6.QtCore import Qt, Slot
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QDialog,
     QWidget,
@@ -16,7 +16,7 @@ from binaryninja import (
     Settings,
     SettingsScope,
 )
-from binaryninjaui import UIContext, DockHandler
+from binaryninjaui import UIContext
 from mui.constants import BINJA_NATIVE_RUN_SETTINGS_PREFIX
 
 

--- a/mui/dockwidgets/library_dialog.py
+++ b/mui/dockwidgets/library_dialog.py
@@ -1,0 +1,105 @@
+import json
+from PySide6.QtCore import Qt, Slot
+from PySide6.QtWidgets import (
+    QDialog,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QListWidget,
+    QListWidgetItem,
+    QFileDialog,
+    QLabel,
+)
+from binaryninja import (
+    BinaryView,
+    Settings,
+    SettingsScope,
+)
+from binaryninjaui import UIContext, DockHandler
+from mui.constants import BINJA_NATIVE_RUN_SETTINGS_PREFIX
+
+
+class LibraryDialog(QDialog):
+    def __init__(self, parent: QWidget, data: BinaryView):
+        self.bv = data
+        self.items = frozenset()
+
+        QDialog.__init__(self, parent)
+
+        self.setWindowTitle("Shared Libraries")
+        self.setMinimumSize(UIContext.getScaledWindowSize(400, 100))
+        self.setAttribute(Qt.WA_DeleteOnClose)
+
+        list_widget = QListWidget(self)
+        self.list_widget = list_widget
+
+        button_layout = QHBoxLayout()
+        del_button = QPushButton("Delete")
+        del_button.clicked.connect(lambda: self.del_lib())
+        add_button = QPushButton("Add")
+        add_button.clicked.connect(lambda: self.add_lib())
+        button_layout.addStretch(1)
+        button_layout.addWidget(del_button)
+        button_layout.addWidget(add_button)
+        button_layout.setContentsMargins(5, 5, 5, 5)
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        layout.addWidget(list_widget)
+        layout.addLayout(button_layout)
+
+        self.setLayout(layout)
+        self.update_items()
+
+    def update_items(self) -> None:
+        """Update missing items into list"""
+        updated = self.bv.session_data.mui_libs
+        diff = updated.difference(self.items)
+        print(diff)
+        if diff:
+            self.items = frozenset(updated)
+            for lib in diff:
+                item = QListWidgetItem(lib, self.list_widget)
+            self.update_settings()
+
+    def add_lib(self) -> None:
+        """Prompt bndb selection and add to libs"""
+        filename, _ = QFileDialog.getOpenFileName(
+            None, "Open shared library project", "", "Binary Ninja database files (*.bndb)"
+        )
+        if filename:
+            self.bv.session_data.mui_libs.add(filename)
+            self.update_items()
+
+    def _del_list_item(self, item: QListWidgetItem) -> None:
+        """Remove item from list"""
+        row = 0
+        list_widget = self.list_widget
+        while row < list_widget.count():
+            cur_item = list_widget.item(row)
+            if cur_item == item:
+                list_widget.takeItem(row)
+                # Don't increment row
+            else:
+                row += 1
+
+    def del_lib(self) -> None:
+        """Delete currently selected lib"""
+        list_widget = self.list_widget
+        selected = list_widget.selectedItems()
+        for item in selected:
+            self._del_list_item(item)
+            self.bv.session_data.mui_libs.remove(item.text())
+            self.update_settings()
+
+    def update_settings(self) -> None:
+        settings = Settings()
+        settings.set_string(
+            f"{BINJA_NATIVE_RUN_SETTINGS_PREFIX}sharedLibraries",
+            json.dumps(list(self.bv.session_data.mui_libs)),
+            view=self.bv,
+            scope=SettingsScope.SettingsResourceScope,
+        )

--- a/mui/dockwidgets/library_dialog.py
+++ b/mui/dockwidgets/library_dialog.py
@@ -58,7 +58,6 @@ class LibraryDialog(QDialog):
         """Update missing items into list"""
         updated = self.bv.session_data.mui_libs
         diff = updated.difference(self.items)
-        print(diff)
         if diff:
             self.items = frozenset(updated)
             for lib in diff:

--- a/mui/hook_manager.py
+++ b/mui/hook_manager.py
@@ -2,6 +2,7 @@ import json
 from typing import Set, Dict, Optional
 from binaryninja import (
     Settings,
+    SettingsScope,
     BinaryView,
     HighlightStandardColor,
 )
@@ -105,7 +106,7 @@ class NativeHookManager:
         return self.bv.session_data.mui_global_hooks
 
     def load_existing_hooks(self) -> None:
-        # restore hook session_data from settings
+        """restore hook session_data from settings"""
         bv = self.bv
         settings = Settings()
 
@@ -143,3 +144,36 @@ class NativeHookManager:
                 self.widget.add_hook(HookType.GLOBAL, 0, name)
 
             self.widget.set_manager(self)
+
+    def save_hooks(self) -> None:
+        """store hook session_data into settings for persistence"""
+        bv = self.bv
+        settings = Settings()
+
+        settings.set_string(
+            f"{BINJA_HOOK_SETTINGS_PREFIX}find",
+            json.dumps(list(bv.session_data.mui_find)),
+            view=bv,
+            scope=SettingsScope.SettingsResourceScope,
+        )
+
+        settings.set_string(
+            f"{BINJA_HOOK_SETTINGS_PREFIX}avoid",
+            json.dumps(list(bv.session_data.mui_avoid)),
+            view=bv,
+            scope=SettingsScope.SettingsResourceScope,
+        )
+
+        settings.set_string(
+            f"{BINJA_HOOK_SETTINGS_PREFIX}custom",
+            json.dumps(bv.session_data.mui_custom_hooks),
+            view=bv,
+            scope=SettingsScope.SettingsResourceScope,
+        )
+
+        settings.set_string(
+            f"{BINJA_HOOK_SETTINGS_PREFIX}global",
+            json.dumps(bv.session_data.mui_global_hooks),
+            view=bv,
+            scope=SettingsScope.SettingsResourceScope,
+        )

--- a/mui/hook_manager.py
+++ b/mui/hook_manager.py
@@ -1,0 +1,145 @@
+import json
+from typing import Set, Dict, Optional
+from binaryninja import (
+    Settings,
+    BinaryView,
+    HighlightStandardColor,
+)
+from mui.constants import BINJA_HOOK_SETTINGS_PREFIX
+from mui.dockwidgets.hook_list_widget import HookListWidget, HookType
+from mui.utils import clear_highlight, highlight_instr
+
+
+class NativeHookManager:
+    """Class to manage mui hooks associated with a specific binary view (bv)"""
+
+    def __init__(self, bv: BinaryView, widget: Optional[HookListWidget] = None):
+        self.bv = bv
+        self.widget = widget
+
+    # Add
+    def add_find_hook(self, addr: int) -> None:
+        bv = self.bv
+        bv.session_data.mui_find.add(addr)
+        highlight_instr(bv, addr, HighlightStandardColor.GreenHighlightColor)
+        if self.widget:
+            self.widget.add_hook(HookType.FIND, addr)
+
+    def add_avoid_hook(self, addr: int) -> None:
+        bv = self.bv
+        bv.session_data.mui_avoid.add(addr)
+        highlight_instr(bv, addr, HighlightStandardColor.RedHighlightColor)
+        if self.widget:
+            self.widget.add_hook(HookType.AVOID, addr)
+
+    def add_custom_hook(self, addr: int, code: str) -> None:
+        bv = self.bv
+        bv.session_data.mui_custom_hooks[addr] = code
+        highlight_instr(bv, addr, HighlightStandardColor.BlueHighlightColor)
+        if self.widget:
+            self.widget.add_hook(HookType.CUSTOM, addr)
+
+    def add_global_hook(self, name: str, code: str) -> None:
+        self.bv.session_data.mui_global_hooks[name] = code
+        if self.widget:
+            self.widget.add_hook(HookType.GLOBAL, 0, name)
+
+    # Delete
+    def del_find_hook(self, addr: int) -> None:
+        bv = self.bv
+        bv.session_data.mui_find.remove(addr)
+        clear_highlight(bv, addr)
+        if self.widget:
+            self.widget.remove_hook(HookType.FIND, addr)
+
+    def del_avoid_hook(self, addr: int) -> None:
+        bv = self.bv
+        bv.session_data.mui_avoid.remove(addr)
+        clear_highlight(bv, addr)
+        if self.widget:
+            self.widget.remove_hook(HookType.AVOID, addr)
+
+    def del_custom_hook(self, addr: int) -> None:
+        bv = self.bv
+        del bv.session_data.mui_custom_hooks[addr]
+        clear_highlight(bv, addr)
+        if self.widget:
+            self.widget.remove_hook(HookType.CUSTOM, addr)
+
+    def del_global_hook(self, name: str) -> None:
+        del self.bv.session_data.mui_global_hooks[name]
+        if self.widget:
+            self.widget.remove_hook(HookType.GLOBAL, 0, name)
+
+    # Has
+    def has_find_hook(self, addr: int) -> bool:
+        return addr in self.bv.session_data.mui_find
+
+    def has_avoid_hook(self, addr: int) -> bool:
+        return addr in self.bv.session_data.mui_avoid
+
+    def has_custom_hook(self, addr: int) -> bool:
+        return addr in self.bv.session_data.mui_custom_hooks
+
+    def has_global_hook(self, name: str) -> bool:
+        return name in self.bv.session_data.mui_global_hooks
+
+    # Get
+    def get_custom_hook(self, addr: int) -> str:
+        return self.bv.session_data.mui_custom_hooks.get(addr, "")
+
+    def get_global_hook(self, name: str) -> str:
+        return self.bv.session_data.mui_global_hooks.get(name, "")
+
+    # List
+    def list_find_hooks(self) -> Set[int]:
+        return self.bv.session_data.mui_find
+
+    def list_avoid_hooks(self) -> Set[int]:
+        return self.bv.session_data.mui_avoid
+
+    def list_custom_hooks(self) -> Dict[int, str]:
+        return self.bv.session_data.mui_custom_hooks
+
+    def list_global_hooks(self) -> Dict[str, str]:
+        return self.bv.session_data.mui_global_hooks
+
+    def load_existing_hooks(self) -> None:
+        # restore hook session_data from settings
+        bv = self.bv
+        settings = Settings()
+
+        bv.session_data.mui_find = set(
+            json.loads(settings.get_string(f"{BINJA_HOOK_SETTINGS_PREFIX}find", bv))
+        )
+        bv.session_data.mui_avoid = set(
+            json.loads(settings.get_string(f"{BINJA_HOOK_SETTINGS_PREFIX}avoid", bv))
+        )
+        bv.session_data.mui_custom_hooks = {
+            int(key): item
+            for key, item in json.loads(
+                settings.get_string(f"{BINJA_HOOK_SETTINGS_PREFIX}custom", bv)
+            ).items()
+        }
+        bv.session_data.mui_global_hooks = {
+            key: item
+            for key, item in json.loads(
+                settings.get_string(f"{BINJA_HOOK_SETTINGS_PREFIX}global", bv)
+            ).items()
+        }
+
+        # Update hook list widget if present
+        if self.widget:
+            for addr in self.list_find_hooks():
+                self.widget.add_hook(HookType.FIND, addr)
+
+            for addr in self.list_avoid_hooks():
+                self.widget.add_hook(HookType.AVOID, addr)
+
+            for addr in self.list_custom_hooks():
+                self.widget.add_hook(HookType.CUSTOM, addr)
+
+            for name in self.list_global_hooks():
+                self.widget.add_hook(HookType.GLOBAL, 0, name)
+
+            self.widget.set_manager(self)

--- a/mui/manticore_native_runner.py
+++ b/mui/manticore_native_runner.py
@@ -13,7 +13,6 @@ from binaryninja import (
 )
 from manticore.core.state import StateBase
 from manticore.native import Manticore
-from manticore.core.plugin import Plugin
 
 from mui.constants import BINJA_NATIVE_RUN_SETTINGS_PREFIX
 from mui.dockwidgets import widget
@@ -197,16 +196,11 @@ class ManticoreNativeRunner(BackgroundTaskThread):
 
         return addr_off
 
-    def load_libraries(self, m: Manticore, find_f: Callable, avoid_f: Callable):
-        bv = self.view
-        mgrs = []
-
-        for lib_name in bv.session_data.mui_libs:
+    def load_libraries(self, m: Manticore, find_f: Callable, avoid_f: Callable) -> None:
+        """Load hooks from shared libraries and rebase hooks"""
+        for lib_name in self.view.session_data.mui_libs:
             print(f"Loading hooks from external library: {lib_name}")
             lib_bv = open_view(lib_name, options={"ui.log.minLevel": "ErrorLog"})
             lib_mgr = NativeHookManager(lib_bv)
             lib_mgr.load_existing_hooks()
-            mgrs.append(lib_mgr)
-
-        for mgr in mgrs:
-            m.register_plugin(RebaseHooksPlugin(mgr, find_f, avoid_f))
+            m.register_plugin(RebaseHooksPlugin(lib_mgr, find_f, avoid_f))

--- a/mui/mui.py
+++ b/mui/mui.py
@@ -33,13 +33,13 @@ from mui.dockwidgets.function_model_dialog import FunctionModelDialog
 from mui.dockwidgets.global_hook_dialog import GlobalHookDialog
 from mui.dockwidgets.state_graph_widget import StateGraphWidget
 from mui.dockwidgets.state_list_widget import StateListWidget
-from mui.dockwidgets.hook_list_widget import HookListWidget, HookType
+from mui.dockwidgets.hook_list_widget import HookListWidget
 from mui.hook_manager import NativeHookManager
 from mui.manticore_evm_runner import ManticoreEVMRunner
 from mui.manticore_native_runner import ManticoreNativeRunner
 from mui.notification import UINotification
 from mui.settings import MUISettings
-from mui.utils import highlight_instr, clear_highlight, function_model_analysis_cb
+from mui.utils import function_model_analysis_cb
 
 settings = Settings()
 

--- a/mui/mui.py
+++ b/mui/mui.py
@@ -34,6 +34,7 @@ from mui.dockwidgets.global_hook_dialog import GlobalHookDialog
 from mui.dockwidgets.state_graph_widget import StateGraphWidget
 from mui.dockwidgets.state_list_widget import StateListWidget
 from mui.dockwidgets.hook_list_widget import HookListWidget, HookType
+from mui.hook_manager import NativeHookManager
 from mui.manticore_evm_runner import ManticoreEVMRunner
 from mui.manticore_native_runner import ManticoreNativeRunner
 from mui.notification import UINotification
@@ -42,6 +43,7 @@ from mui.utils import highlight_instr, clear_highlight, function_model_analysis_
 
 settings = Settings()
 
+BinaryView.set_default_session_data("mui_hook_mgr", None)
 BinaryView.set_default_session_data("mui_find", set())
 BinaryView.set_default_session_data("mui_avoid", set())
 BinaryView.set_default_session_data("mui_custom_hooks", dict())
@@ -54,58 +56,26 @@ BinaryView.set_default_session_data("mui_addr_offset", None)
 
 def find_instr(bv: BinaryView, addr: int):
     """This command handler adds a given address to the find list and highlights it green in the UI"""
-
-    # Highlight the instruction in green
-    highlight_instr(bv, addr, HighlightStandardColor.GreenHighlightColor)
-
-    # Add the instruction to the list associated with the current view
-    bv.session_data.mui_find.add(addr)
-
-    # Add to hook list widget
-    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
-    hook_widget.add_hook(HookType.FIND, addr)
+    mgr: NativeHookManager = bv.session_data.mui_hook_mgr
+    mgr.add_find_hook(addr)
 
 
 def rm_find_instr(bv: BinaryView, addr: int):
     """This command handler removes a given address from the find list and undoes the highlights"""
-
-    # Remove instruction highlight
-    clear_highlight(bv, addr)
-
-    # Remove the instruction to the list associated with the current view
-    bv.session_data.mui_find.remove(addr)
-
-    # Remove from hook list widget
-    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
-    hook_widget.remove_hook(HookType.FIND, addr)
+    mgr: NativeHookManager = bv.session_data.mui_hook_mgr
+    mgr.del_find_hook(addr)
 
 
 def avoid_instr(bv: BinaryView, addr: int):
     """This command handler adds a given address to the avoid list and highlights it red in the UI"""
-
-    # Highlight the instruction in red
-    highlight_instr(bv, addr, HighlightStandardColor.RedHighlightColor)
-
-    # Add the instruction to the list associated with the current view
-    bv.session_data.mui_avoid.add(addr)
-
-    # Add to hook list widget
-    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
-    hook_widget.add_hook(HookType.AVOID, addr)
+    mgr: NativeHookManager = bv.session_data.mui_hook_mgr
+    mgr.add_avoid_hook(addr)
 
 
 def rm_avoid_instr(bv: BinaryView, addr: int):
     """This command handler removes a given address from the avoid list and undoes the highlights"""
-
-    # Remove instruction highlight
-    clear_highlight(bv, addr)
-
-    # Remove the instruction to the list associated with the current view
-    bv.session_data.mui_avoid.remove(addr)
-
-    # Remove from hook list widget
-    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
-    hook_widget.remove_hook(HookType.AVOID, addr)
+    mgr: NativeHookManager = bv.session_data.mui_hook_mgr
+    mgr.del_avoid_hook(addr)
 
 
 def solve(bv: BinaryView):
@@ -163,44 +133,37 @@ def solve(bv: BinaryView):
         if dialog.exec() == QDialog.Accepted:
             # Start a solver thread for the path associated with the view
             bv.session_data.mui_is_running = True
-            s = ManticoreNativeRunner(bv.session_data.mui_find, bv.session_data.mui_avoid, bv)
+            s = ManticoreNativeRunner(bv, bv.session_data.mui_hook_mgr)
             s.start()
 
 
 def edit_custom_hook(bv: BinaryView, addr: int):
     dialog = CodeDialog(DockHandler.getActiveDockHandler().parent(), bv)
-    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
+    mgr: NativeHookManager = bv.session_data.mui_hook_mgr
 
-    if addr in bv.session_data.mui_custom_hooks:
-        dialog.set_text(bv.session_data.mui_custom_hooks[addr])
+    if mgr.has_custom_hook(addr):
+        dialog.set_text(mgr.get_custom_hook(addr))
 
     result: QDialog.DialogCode = dialog.exec()
 
     if result == QDialog.Accepted:
-
-        if len(dialog.text()) == 0:
+        code = dialog.text()
+        if not code:
             # delete the hook if empty input is provided
-            if addr in bv.session_data.mui_custom_hooks:
-                clear_highlight(bv, addr)
-                del bv.session_data.mui_custom_hooks[addr]
-                hook_widget.remove_hook(HookType.CUSTOM, addr)
-
+            if mgr.has_custom_hook(addr):
+                mgr.del_custom_hook(addr)
         else:
-            # add/edit the hook if input is non-empty
-            highlight_instr(bv, addr, HighlightStandardColor.BlueHighlightColor)
-            # add to hook list if new
-            if addr not in bv.session_data.mui_custom_hooks:
-                hook_widget.add_hook(HookType.CUSTOM, addr)
-            bv.session_data.mui_custom_hooks[addr] = dialog.text()
+            mgr.add_custom_hook(addr, code)
 
 
 def edit_global_hook(bv: BinaryView):
-    dialog = GlobalHookDialog(DockHandler.getActiveDockHandler().parent(), bv)
+    mgr: NativeHookManager = bv.session_data.mui_hook_mgr
+    dialog = GlobalHookDialog(DockHandler.getActiveDockHandler().parent(), bv, mgr)
     dialog.exec()
 
 
 def add_function_model(bv: BinaryView, addr: int) -> None:
-    hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
+    mgr: NativeHookManager = bv.session_data.mui_hook_mgr
     dialog = FunctionModelDialog(DockHandler.getActiveDockHandler().parent(), bv)
     result: QDialog.DialogCode = dialog.exec()
 
@@ -209,8 +172,6 @@ def add_function_model(bv: BinaryView, addr: int) -> None:
         if not fname:
             return
 
-        highlight_instr(bv, addr, HighlightStandardColor.BlueHighlightColor)
-        hook_widget.add_hook(HookType.CUSTOM, addr)
         code = "\n".join(
             [
                 f"from manticore.native.models import {fname}",
@@ -221,7 +182,7 @@ def add_function_model(bv: BinaryView, addr: int) -> None:
                 "m.hook(addr)(hook)",
             ]
         )
-        bv.session_data.mui_custom_hooks[addr] = code
+        mgr.add_custom_hook(addr, code)
 
 
 def load_evm(bv: BinaryView):
@@ -265,12 +226,18 @@ def stop_manticore(bv: BinaryView):
 
 def avoid_instr_is_valid(bv: BinaryView, addr: int):
     """checks if avoid_instr is valid for a given address"""
-    return addr not in bv.session_data.mui_avoid
+    if bv.session_data.mui_hook_mgr:
+        return not bv.session_data.mui_hook_mgr.has_avoid_hook(addr)
+    else:
+        return True
 
 
 def find_instr_is_valid(bv: BinaryView, addr: int):
     """checks if find_instr is valid for a given address"""
-    return addr not in bv.session_data.mui_find
+    if bv.session_data.mui_hook_mgr:
+        return not bv.session_data.mui_hook_mgr.has_find_hook(addr)
+    else:
+        return True
 
 
 def solve_is_valid(bv: BinaryView):

--- a/mui/mui.py
+++ b/mui/mui.py
@@ -9,7 +9,6 @@ from PySide6.QtWidgets import QDialog
 from binaryninja import (
     PluginCommand,
     BinaryView,
-    HighlightStandardColor,
     show_message_box,
     MessageBoxButtonSet,
     MessageBoxIcon,
@@ -28,6 +27,7 @@ from mui.constants import (
 )
 from mui.dockwidgets import widget
 from mui.dockwidgets.code_dialog import CodeDialog
+from mui.dockwidgets.library_dialog import LibraryDialog
 from mui.dockwidgets.run_dialog import RunDialog
 from mui.dockwidgets.function_model_dialog import FunctionModelDialog
 from mui.dockwidgets.global_hook_dialog import GlobalHookDialog
@@ -52,6 +52,7 @@ BinaryView.set_default_session_data("mui_is_running", False)
 BinaryView.set_default_session_data("mui_state", None)
 BinaryView.set_default_session_data("mui_evm_source", None)
 BinaryView.set_default_session_data("mui_addr_offset", None)
+BinaryView.set_default_session_data("mui_libs", set())
 
 
 def find_instr(bv: BinaryView, addr: int):
@@ -185,6 +186,11 @@ def add_function_model(bv: BinaryView, addr: int) -> None:
         mgr.add_custom_hook(addr, code)
 
 
+def manage_shared_libs(bv) -> None:
+    dialog = LibraryDialog(DockHandler.getActiveDockHandler().parent(), bv)
+    dialog.exec()
+
+
 def load_evm(bv: BinaryView):
     filename = get_open_filename_input("filename:", "*.sol").decode()
     if filename is None:
@@ -297,6 +303,11 @@ PluginCommand.register(
     "MUI \\ Add/Edit Global Hook",
     "Add/edit a custom hook that applies to all instructions",
     edit_global_hook,
+)
+PluginCommand.register(
+    "MUI \\ Manage Shared Library BNDBs",
+    "Manage shared library bndbs to extract hooks from",
+    manage_shared_libs,
 )
 
 widget.register_dockwidget(

--- a/mui/native_plugin.py
+++ b/mui/native_plugin.py
@@ -1,4 +1,5 @@
 from typing import Callable
+from os.path import realpath
 from manticore.core.plugin import Plugin
 from mui.hook_manager import NativeHookManager
 
@@ -30,10 +31,17 @@ class RebaseHooksPlugin(Plugin):
         # Hack: call m.add_hook once to subscribe _hook_callback
         m.hook(0)(lambda state: state)
 
+    def matching_name(self, filename) -> bool:
+        """Checks if filename matches with the library name"""
+        if filename:
+            return realpath(self.filename) == realpath(filename)
+        else:
+            return False
+
     def did_map_memory_callback(self, _state, addr, _size, _perms, filename, offset, _addr):
         """Rebases hooks from library to loaded base address"""
         # If binary base is being loaded
-        if filename == self.filename and offset == 0:
+        if self.matching_name(filename) and offset == 0:
             print(f"{filename} mapped @ {addr:#x}")
             with self.locked_context():
                 m = self.manticore

--- a/mui/native_plugin.py
+++ b/mui/native_plugin.py
@@ -22,7 +22,7 @@ class RebaseHooksPlugin(Plugin):
         mgr.bv.file.close()
 
     def on_register(self):
-        """ Called by parent manticore on registration (enable global hooks) """
+        """Called by parent manticore on registration (enable global hooks)"""
         m = self.manticore
         for func in self.global_hooks:
             exec(func, {"bv": None, "m": m})
@@ -31,7 +31,7 @@ class RebaseHooksPlugin(Plugin):
         m.hook(0)(lambda state: state)
 
     def did_map_memory_callback(self, _state, addr, _size, _perms, filename, offset, _addr):
-        """ Rebases hooks from library to loaded base address """
+        """Rebases hooks from library to loaded base address"""
         # If binary base is being loaded
         if filename == self.filename and offset == 0:
             print(f"{filename} mapped @ {addr:#x}")

--- a/mui/native_plugin.py
+++ b/mui/native_plugin.py
@@ -50,6 +50,7 @@ class RebaseHooksPlugin(Plugin):
 
                 # Hack: make m.subscribe != None to prevent error in mcore
                 # We don't need subscribe, we just want our hooks to be in m._hooks
+                subscribe = m.subscribe
                 m.subscribe = lambda x, y: None
 
                 for hook_addr in self.avoid:
@@ -62,7 +63,7 @@ class RebaseHooksPlugin(Plugin):
                     exec(func, {"addr": hook_addr + self.base, "bv": None, "m": m})
 
                 # Undo our hack to maintain original manticore behaviour
-                m.subscribe = None
+                m.subscribe = subscribe
 
 
 class UnicornEmulatePlugin(Plugin):

--- a/mui/native_plugin.py
+++ b/mui/native_plugin.py
@@ -1,0 +1,57 @@
+from typing import Callable
+from manticore.core.plugin import Plugin
+from mui.hook_manager import NativeHookManager
+
+
+class RebaseHooksPlugin(Plugin):
+    def __init__(self, mgr: NativeHookManager, find_f: Callable, avoid_f: Callable):
+        super().__init__()
+        self.find_f = find_f
+        self.avoid_f = avoid_f
+        self.filename = mgr.bv.file.original_filename
+        self.base = 0
+        self.loaded = False
+
+        # Hooks
+        self.find = mgr.list_find_hooks()
+        self.avoid = mgr.list_avoid_hooks()
+        self.custom_hooks = [(addr, func) for addr, func in mgr.list_custom_hooks().items()]
+        self.global_hooks = list(mgr.list_global_hooks().values())
+
+        # Close binary view, don't use after this
+        mgr.bv.file.close()
+
+    def on_register(self):
+        """ Called by parent manticore on registration (enable global hooks) """
+        m = self.manticore
+        for func in self.global_hooks:
+            exec(func, {"bv": None, "m": m})
+
+        # Hack: call m.add_hook once to subscribe _hook_callback
+        m.hook(0)(lambda state: state)
+
+    def did_map_memory_callback(self, _state, addr, _size, _perms, filename, offset, _addr):
+        """ Rebases hooks from library to loaded base address """
+        # If binary base is being loaded
+        if filename == self.filename and offset == 0:
+            print(f"{filename} mapped @ {addr:#x}")
+            with self.locked_context():
+                m = self.manticore
+                self.loaded = True
+                self.base = addr
+
+                # Hack: make m.subscribe != None to prevent error in mcore
+                # We don't need subscribe, we just want our hooks to be in m._hooks
+                m.subscribe = lambda x, y: None
+
+                for hook_addr in self.avoid:
+                    m.hook(hook_addr + self.base)(self.avoid_f)
+
+                for hook_addr in self.find:
+                    m.hook(hook_addr + self.base)(self.find_f)
+
+                for hook_addr, func in self.custom_hooks:
+                    exec(func, {"addr": hook_addr + self.base, "bv": None, "m": m})
+
+                # Undo our hack to maintain original manticore behaviour
+                m.subscribe = None

--- a/mui/native_plugin.py
+++ b/mui/native_plugin.py
@@ -55,3 +55,15 @@ class RebaseHooksPlugin(Plugin):
 
                 # Undo our hack to maintain original manticore behaviour
                 m.subscribe = None
+
+
+class UnicornEmulatePlugin(Plugin):
+    """Manticore plugin to speed up emulation using unicorn until `start`"""
+
+    def __init__(self, start: int):
+        super().__init__()
+        self.start = start
+
+    def will_run_callback(self, ready_states):
+        for state in ready_states:
+            state.cpu.emulate_until(self.start)

--- a/mui/notification.py
+++ b/mui/notification.py
@@ -52,36 +52,10 @@ class UINotification(UIContextNotification):
 
     def OnBeforeSaveFile(self, context: UIContext, file: FileContext, frame: ViewFrame) -> bool:
         """Update settings to reflect the latest session_data"""
-
         bv: BinaryView = frame.getCurrentBinaryView()
-        settings = Settings()
+        mgr: NativeHookManager = bv.session_data.mui_hook_mgr
 
-        settings.set_string(
-            f"{BINJA_HOOK_SETTINGS_PREFIX}find",
-            json.dumps(list(bv.session_data.mui_find)),
-            view=bv,
-            scope=SettingsScope.SettingsResourceScope,
-        )
-
-        settings.set_string(
-            f"{BINJA_HOOK_SETTINGS_PREFIX}avoid",
-            json.dumps(list(bv.session_data.mui_avoid)),
-            view=bv,
-            scope=SettingsScope.SettingsResourceScope,
-        )
-
-        settings.set_string(
-            f"{BINJA_HOOK_SETTINGS_PREFIX}custom",
-            json.dumps(bv.session_data.mui_custom_hooks),
-            view=bv,
-            scope=SettingsScope.SettingsResourceScope,
-        )
-
-        settings.set_string(
-            f"{BINJA_HOOK_SETTINGS_PREFIX}global",
-            json.dumps(bv.session_data.mui_global_hooks),
-            view=bv,
-            scope=SettingsScope.SettingsResourceScope,
-        )
+        if mgr:
+            mgr.save_hooks()
 
         return True

--- a/mui/notification.py
+++ b/mui/notification.py
@@ -3,7 +3,7 @@ import json
 from binaryninja import BinaryView, FileMetadata, Settings, HighlightStandardColor, SettingsScope
 from binaryninjaui import UIContextNotification, UIContext, FileContext, ViewFrame
 
-from mui.constants import BINJA_HOOK_SETTINGS_PREFIX
+from mui.constants import BINJA_HOOK_SETTINGS_PREFIX, BINJA_NATIVE_RUN_SETTINGS_PREFIX
 from mui.hook_manager import NativeHookManager
 from mui.utils import highlight_instr
 from mui.dockwidgets.hook_list_widget import HookListWidget
@@ -40,6 +40,15 @@ class UINotification(UIContextNotification):
             highlight_instr(bv, addr, HighlightStandardColor.RedHighlightColor)
         for addr in mgr.list_custom_hooks():
             highlight_instr(bv, addr, HighlightStandardColor.BlueHighlightColor)
+
+        # restore shared libraries
+        settings = Settings()
+        libs = set(
+            json.loads(
+                settings.get_string(f"{BINJA_NATIVE_RUN_SETTINGS_PREFIX}sharedLibraries", bv)
+            )
+        )
+        bv.session_data.mui_libs = libs
 
     def OnBeforeSaveFile(self, context: UIContext, file: FileContext, frame: ViewFrame) -> bool:
         """Update settings to reflect the latest session_data"""

--- a/mui/notification.py
+++ b/mui/notification.py
@@ -4,6 +4,7 @@ from binaryninja import BinaryView, FileMetadata, Settings, HighlightStandardCol
 from binaryninjaui import UIContextNotification, UIContext, FileContext, ViewFrame
 
 from mui.constants import BINJA_HOOK_SETTINGS_PREFIX
+from mui.hook_manager import NativeHookManager
 from mui.utils import highlight_instr
 from mui.dockwidgets.hook_list_widget import HookListWidget
 from mui.dockwidgets import widget
@@ -23,40 +24,21 @@ class UINotification(UIContextNotification):
 
     def OnAfterOpenFile(self, context: UIContext, file: FileContext, frame: ViewFrame) -> None:
         """Restore existing settings right after file open"""
-
         bv: BinaryView = frame.getCurrentBinaryView()
 
-        # restore hook session_data from settings
-        settings = Settings()
-        bv.session_data.mui_find = set(
-            json.loads(settings.get_string(f"{BINJA_HOOK_SETTINGS_PREFIX}find", bv))
-        )
-        bv.session_data.mui_avoid = set(
-            json.loads(settings.get_string(f"{BINJA_HOOK_SETTINGS_PREFIX}avoid", bv))
-        )
-        bv.session_data.mui_custom_hooks = {
-            int(key): item
-            for key, item in json.loads(
-                settings.get_string(f"{BINJA_HOOK_SETTINGS_PREFIX}custom", bv)
-            ).items()
-        }
-        bv.session_data.mui_global_hooks = {
-            key: item
-            for key, item in json.loads(
-                settings.get_string(f"{BINJA_HOOK_SETTINGS_PREFIX}global", bv)
-            ).items()
-        }
-
-        # initialise hook list widget
+        # initialise hook manager
         hook_widget: HookListWidget = widget.get_dockwidget(bv, HookListWidget.NAME)
-        hook_widget.load_existing_hooks()
+
+        mgr = NativeHookManager(bv, hook_widget)
+        bv.session_data.mui_hook_mgr = mgr
+        mgr.load_existing_hooks()
 
         # restore highlight
-        for addr in bv.session_data.mui_find:
+        for addr in mgr.list_find_hooks():
             highlight_instr(bv, addr, HighlightStandardColor.GreenHighlightColor)
-        for addr in bv.session_data.mui_avoid:
+        for addr in mgr.list_avoid_hooks():
             highlight_instr(bv, addr, HighlightStandardColor.RedHighlightColor)
-        for addr in bv.session_data.mui_custom_hooks.keys():
+        for addr in mgr.list_custom_hooks():
             highlight_instr(bv, addr, HighlightStandardColor.BlueHighlightColor)
 
     def OnBeforeSaveFile(self, context: UIContext, file: FileContext, frame: ViewFrame) -> bool:

--- a/mui/settings.py
+++ b/mui/settings.py
@@ -89,6 +89,15 @@ class MUISettings:
                 },
                 {},
             ),
+            "sharedLibraries": (
+                {
+                    "title": "Shared Libraries",
+                    "description": "Shared library bndbs to extract mui hooks from",
+                    "type": "string",
+                    "default": "[]",
+                },
+                {},
+            ),
         },
         BINJA_HOOK_SETTINGS_PREFIX: {
             "avoid": (


### PR DESCRIPTION
This PR implements a new feature that allows MUI users to add bndb files of shared libraries used by the binaries (i.e. libc) to the project. The MUI hooks from these external bndbs will be extracted and added when MUI solve is run. This allows us to have "multi-file" projects.

Summary of code changes:
- Refactor of hook management code to decouple code from directly managing session data 
- Additional command `MUI - Manage Shared Library BNDBs`
- Additional dialog that allows adding and deletion of shared library bndbs