### PR TITLE
Server Integration: Specify arbitrary arguments, CLI-style

### DIFF
--- a/mui/mui.py
+++ b/mui/mui.py
@@ -97,24 +97,6 @@ def solve(bv: BinaryView):
         and bv.arch == Architecture["EVM"]
         and bv.session_data.mui_evm_source is not None
     ):
-        # set default workspace url
-
-        workspace_url = settings.get_string(f"{BINJA_EVM_RUN_SETTINGS_PREFIX}workspace_url", bv)
-        if workspace_url == "":
-
-            random_dir_name = "".join(random.choices(string.ascii_uppercase + string.digits, k=10))
-            workspace_url = str(
-                Path(
-                    bv.session_data.mui_evm_source.parent.resolve(),
-                    random_dir_name,
-                )
-            )
-            settings.set_string(
-                f"{BINJA_EVM_RUN_SETTINGS_PREFIX}workspace_url",
-                workspace_url,
-                view=bv,
-                scope=SettingsScope.SettingsResourceScope,
-            )
 
         dialog = RunDialog(
             DockHandler.getActiveDockHandler().parent(), bv, BINJA_EVM_RUN_SETTINGS_PREFIX

--- a/mui/mui.py
+++ b/mui/mui.py
@@ -143,7 +143,25 @@ def solve(bv: BinaryView):
             if not isinstance(notif.mui_client_stub, ManticoreUIStub):
                 notif.mui_client_stub = create_client_stub()
             mcore_instance = notif.mui_client_stub.StartNative(
-                NativeArguments(program_path=bv.file.original_filename)
+                NativeArguments(
+                    program_path=bv.file.original_filename,
+                    binary_args=settings.get_string_list(
+                        f"{BINJA_NATIVE_RUN_SETTINGS_PREFIX}argv", bv
+                    ).copy(),
+                    envp=settings.get_string_list(f"{BINJA_NATIVE_RUN_SETTINGS_PREFIX}env", bv),
+                    symbolic_files=settings.get_string_list(
+                        f"{BINJA_NATIVE_RUN_SETTINGS_PREFIX}symbolicFiles", bv
+                    ),
+                    concrete_start=settings.get_string(
+                        f"{BINJA_NATIVE_RUN_SETTINGS_PREFIX}concreteStart", bv
+                    ),
+                    stdin_size=str(
+                        settings.get_integer(f"{BINJA_NATIVE_RUN_SETTINGS_PREFIX}stdinSize", bv)
+                    ),
+                    additional_mcore_args=settings.get_string(
+                        f"{BINJA_NATIVE_RUN_SETTINGS_PREFIX}additionalArguments", bv
+                    ),
+                )
             )
             bv.session_data.server_manticore_instances.add(mcore_instance.uuid)
             print("Manticore instance created on the server with uuid=" + mcore_instance.uuid)

--- a/mui/settings.py
+++ b/mui/settings.py
@@ -60,7 +60,7 @@ class MUISettings:
             ),
             "emulateUntil": (
                 {
-                    "title": "Emulate until address (in hex)",
+                    "title": "Emulate until address (in hex) (unsupported)",
                     "description": "Emulate using unicorn until address is reached",
                     "type": "string",
                     "default": "",
@@ -69,7 +69,7 @@ class MUISettings:
             ),
             "workspaceURL": (
                 {
-                    "title": "Workspace URL",
+                    "title": "Workspace URL (unsupported)",
                     "description": "Workspace URL to use for manticore",
                     "type": "string",
                     "default": "mem:",
@@ -100,7 +100,7 @@ class MUISettings:
             ),
             "sharedLibraries": (
                 {
-                    "title": "Shared Libraries",
+                    "title": "Shared Libraries (unsupported)",
                     "description": "Shared library bndbs to extract mui hooks from",
                     "type": "string",
                     "default": "[]",
@@ -165,17 +165,6 @@ class MUISettings:
                 },
                 {
                     "is_file_path": True,
-                },
-            ),
-            "workspace_url": (
-                {
-                    "title": "workspace_url",
-                    "description": "Location for the manticore workspace",
-                    "type": "string",
-                    "default": "",
-                },
-                {
-                    "is_dir_path": True,
                 },
             ),
             "contract_name": (

--- a/mui/settings.py
+++ b/mui/settings.py
@@ -107,6 +107,15 @@ class MUISettings:
                 },
                 {},
             ),
+            "additionalArguments": (
+                {
+                    "title": "Additional Arguments",
+                    "description": "CLI-style additional Manticore arguments",
+                    "type": "string",
+                    "default": "",
+                },
+                {},
+            ),
         },
         BINJA_HOOK_SETTINGS_PREFIX: {
             "avoid": (
@@ -344,6 +353,15 @@ class MUISettings:
                     "description": "Avoid exploring constant functions for human transactions",
                     "type": "boolean",
                     "default": False,
+                },
+                {},
+            ),
+            "additionalArguments": (
+                {
+                    "title": "Additional Arguments",
+                    "description": "CLI-style additional Manticore arguments",
+                    "type": "string",
+                    "default": "",
                 },
                 {},
             ),

--- a/mui/settings.py
+++ b/mui/settings.py
@@ -356,15 +356,6 @@ class MUISettings:
                 },
                 {},
             ),
-            "additionalArguments": (
-                {
-                    "title": "Additional Arguments",
-                    "description": "CLI-style additional Manticore arguments",
-                    "type": "string",
-                    "default": "",
-                },
-                {},
-            ),
         },
     }
 


### PR DESCRIPTION
As per https://github.com/trailofbits/ManticoreUI/issues/54, adds a text field in the run dialog that allows users to write, CLI-style, any additional manticore arguments they want. 

Mimics behaviour in the Ghidra plugin and uses the existing protobuf attribute made for this purpose.

Another small side-effect is that the options in the RunDialog now also work except for those denoted in the UI as "unsupported"