### PR TITLE
Add manual state killing support

### DIFF
--- a/mui/dockwidgets/state_list_widget.py
+++ b/mui/dockwidgets/state_list_widget.py
@@ -88,7 +88,7 @@ class StateListWidget(QWidget, DockContextHandler):
                 return True
 
             menu = QMenu()
-            # Options for active states:
+            # Options for active states
             if item.parent() in [self.active_states, self.paused_states, self.waiting_states]:
                 menu.addAction(StateListWidget.CTX_MENU_KILL)
                 if item.parent() == self.paused_states:

--- a/mui/dockwidgets/state_list_widget.py
+++ b/mui/dockwidgets/state_list_widget.py
@@ -24,6 +24,7 @@ class StateListWidget(QWidget, DockContextHandler):
     STATE_ID_ROLE: Final[int] = Qt.UserRole
 
     # Context menu labels
+    CTX_MENU_KILL: Final[str] = "Kill"
     CTX_MENU_PAUSE: Final[str] = "Pause"
     CTX_MENU_RESUME: Final[str] = "Resume"
 
@@ -87,10 +88,14 @@ class StateListWidget(QWidget, DockContextHandler):
                 return True
 
             menu = QMenu()
-            if item.parent() == self.paused_states:
-                menu.addAction(StateListWidget.CTX_MENU_RESUME)
-            else:
-                menu.addAction(StateListWidget.CTX_MENU_PAUSE)
+            # Options for active states:
+            if item.parent() in [self.active_states, self.paused_states, self.waiting_states]:
+                menu.addAction(StateListWidget.CTX_MENU_KILL)
+                if item.parent() == self.paused_states:
+                    menu.addAction(StateListWidget.CTX_MENU_RESUME)
+                else:
+                    menu.addAction(StateListWidget.CTX_MENU_PAUSE)
+
             action = menu.exec(event.globalPos())
 
             m = bv.session_data.mui_cur_m
@@ -99,6 +104,8 @@ class StateListWidget(QWidget, DockContextHandler):
                     bv.session_data.mui_state.pause_state(state_id)
                 elif action.text() == StateListWidget.CTX_MENU_RESUME:
                     bv.session_data.mui_state.resume_state(state_id)
+                elif action.text() == StateListWidget.CTX_MENU_KILL:
+                    bv.session_data.mui_state.kill_state(state_id)
 
             return True
 

--- a/mui/dockwidgets/state_list_widget.py
+++ b/mui/dockwidgets/state_list_widget.py
@@ -42,16 +42,16 @@ class StateListWidget(QWidget, DockContextHandler):
         tree_widget.installEventFilter(self)
 
         self.active_states = QTreeWidgetItem(None, ["Active"])
-        self.paused_states = QTreeWidgetItem(None, ["Paused"])
         self.waiting_states = QTreeWidgetItem(None, ["Waiting"])
+        self.paused_states = QTreeWidgetItem(None, ["Paused"])
         self.forked_states = QTreeWidgetItem(None, ["Forked"])
         self.complete_states = QTreeWidgetItem(None, ["Complete"])
         self.error_states = QTreeWidgetItem(None, ["Errored"])
 
         self.state_lists = [
             self.active_states,
-            self.paused_states,
             self.waiting_states,
+            self.paused_states,
             self.forked_states,
             self.complete_states,
             self.error_states,

--- a/mui/dockwidgets/state_list_widget.py
+++ b/mui/dockwidgets/state_list_widget.py
@@ -90,11 +90,11 @@ class StateListWidget(QWidget, DockContextHandler):
             menu = QMenu()
             # Options for active states
             if item.parent() in [self.active_states, self.paused_states, self.waiting_states]:
-                menu.addAction(StateListWidget.CTX_MENU_KILL)
                 if item.parent() == self.paused_states:
                     menu.addAction(StateListWidget.CTX_MENU_RESUME)
                 else:
                     menu.addAction(StateListWidget.CTX_MENU_PAUSE)
+                menu.addAction(StateListWidget.CTX_MENU_KILL)
 
             action = menu.exec(event.globalPos())
 

--- a/mui/dockwidgets/state_list_widget.py
+++ b/mui/dockwidgets/state_list_widget.py
@@ -96,20 +96,9 @@ class StateListWidget(QWidget, DockContextHandler):
             m = bv.session_data.mui_cur_m
             if action:
                 if action.text() == StateListWidget.CTX_MENU_PAUSE:
-                    # Add dummy busy state to prevent from manticore finishing
-                    if not bv.session_data.mui_state.paused_states:
-                        with m._lock:
-                            m._busy_states.append(-1)
-                            m._lock.notify_all()
-                    bv.session_data.mui_state.paused_states.add(state_id)
+                    bv.session_data.mui_state.pause_state(state_id)
                 elif action.text() == StateListWidget.CTX_MENU_RESUME:
-                    bv.session_data.mui_state.paused_states.remove(state_id)
-                    with m._lock:
-                        m._revive_state(state_id)
-                        # Remove dummy busy state if no more paused states
-                        if not bv.session_data.mui_state.paused_states:
-                            m._busy_states.remove(-1)
-                        m._lock.notify_all()
+                    bv.session_data.mui_state.resume_state(state_id)
 
             return True
 

--- a/mui/manticore_native_runner.py
+++ b/mui/manticore_native_runner.py
@@ -59,6 +59,7 @@ class ManticoreNativeRunner(BackgroundTaskThread):
 
             bv.session_data.mui_state.notify_states_changed({})
             bv.session_data.mui_state.paused_states = set()
+            bv.session_data.mui_state.state_callbacks = dict()
 
             settings = Settings()
 

--- a/mui/manticore_native_runner.py
+++ b/mui/manticore_native_runner.py
@@ -132,7 +132,7 @@ class ManticoreNativeRunner(BackgroundTaskThread):
             for func in self.global_hooks:
                 exec(func, {"bv": bv, "m": m})
 
-            # Global hook for mui_state to add state-specific hooks
+            # Global hook for mui_state to add state-specific callbacks
             m.hook(None)(bv.session_data.mui_state.state_callback_hook)
 
             self.load_libraries(m, find_f, avoid_f)

--- a/mui/manticore_native_runner.py
+++ b/mui/manticore_native_runner.py
@@ -132,12 +132,8 @@ class ManticoreNativeRunner(BackgroundTaskThread):
             for func in self.global_hooks:
                 exec(func, {"bv": bv, "m": m})
 
-            # Global hook to pause specific states
-            def pause_hook(state: StateBase):
-                if state.id in bv.session_data.mui_state.paused_states:
-                    raise TerminateState("Pausing state")
-
-            m.hook(None)(pause_hook)
+            # Global hook for mui_state to add state-specific hooks
+            m.hook(None)(bv.session_data.mui_state.state_callback_hook)
 
             self.load_libraries(m, find_f, avoid_f)
 

--- a/mui/utils.py
+++ b/mui/utils.py
@@ -109,7 +109,7 @@ class MUIState:
     def _unregister_state_callback(self, state_id: int, callback: typing.Callable) -> None:
         """Registers a callback to be called by a specific state"""
         callbacks = self.state_callbacks.get(state_id, set())
-        if callbacks and callback in callbacks:
+        if callback in callbacks:
             callbacks.remove(callback)
 
     def pause_state(self, state_id: int) -> None:
@@ -146,7 +146,9 @@ class MUIState:
             if state_id in self.paused_states:
                 self.paused_states.remove(state_id)
                 if not self.paused_states:
-                    m._busy_states.remove(-1)
+                    with m._lock:
+                        m._busy_states.remove(-1)
+                        m._lock.notify_all()
             else:
                 self._register_state_callback(state_id, self.state_kill_hook)
 

--- a/mui/utils.py
+++ b/mui/utils.py
@@ -84,35 +84,35 @@ class MUIState:
 
         self.states = new_states
 
-    def state_callback_hook(self, state: StateBase):
+    def state_callback_hook(self, state: StateBase) -> None:
         """Global hook that calls any callbacks that are tied to specific states"""
         callbacks = self.state_callbacks.get(state.id, set())
         for callback in callbacks:
             callback(state)
 
-    def state_pause_hook(self, state: StateBase):
+    def state_pause_hook(self, state: StateBase) -> None:
         """Global manticore hook that pauses the state (runs once and self-removes)"""
         self._unregister_state_callback(state.id, self.state_pause_hook)
         raise TerminateState("Pausing state")
 
-    def state_kill_hook(self, state: StateBase):
+    def state_kill_hook(self, state: StateBase) -> None:
         """Global manticore hook that kills the state (runs once and self-removes)"""
         self._unregister_state_callback(state.id, self.state_kill_hook)
         state.abandon()
 
-    def _register_state_callback(self, state_id: int, callback: typing.Callable):
+    def _register_state_callback(self, state_id: int, callback: typing.Callable) -> None:
         """Registers a callback to be called by a specific state"""
         callbacks = self.state_callbacks.get(state_id, set())
         callbacks.add(callback)
         self.state_callbacks[state_id] = callbacks
 
-    def _unregister_state_callback(self, state_id: int, callback: typing.Callable):
+    def _unregister_state_callback(self, state_id: int, callback: typing.Callable) -> None:
         """Registers a callback to be called by a specific state"""
         callbacks = self.state_callbacks.get(state_id, set())
         if callbacks and callback in callbacks:
             callbacks.remove(callback)
 
-    def pause_state(self, state_id: int):
+    def pause_state(self, state_id: int) -> None:
         bv = self.bv
         m = bv.session_data.mui_cur_m
         # Only pause when running
@@ -125,7 +125,7 @@ class MUIState:
             self._register_state_callback(state_id, self.state_pause_hook)
             self.paused_states.add(state_id)
 
-    def resume_state(self, state_id: int):
+    def resume_state(self, state_id: int) -> None:
         bv = self.bv
         m = bv.session_data.mui_cur_m
         # Only resume when running
@@ -138,7 +138,7 @@ class MUIState:
                     m._busy_states.remove(-1)
                 m._lock.notify_all()
 
-    def kill_state(self, state_id: int):
+    def kill_state(self, state_id: int) -> None:
         bv = self.bv
         m = bv.session_data.mui_cur_m
         # Only kill when running

--- a/mui/utils.py
+++ b/mui/utils.py
@@ -83,13 +83,13 @@ class MUIState:
             callback(old_states, new_states)
 
         self.states = new_states
-    
+
     def state_callback_hook(self, state: StateBase):
         """Global hook that calls any callbacks that are tied to specific states"""
         callbacks = self.state_callbacks.get(state.id, set())
         for callback in callbacks:
             callback(state)
-    
+
     def state_pause_hook(self, state: StateBase):
         """Global manticore hook that pauses the state (runs once and self-removes)"""
         self._unregister_state_callback(state.id, self.state_pause_hook)
@@ -111,7 +111,7 @@ class MUIState:
         callbacks = self.state_callbacks.get(state_id, set())
         if callbacks and callback in callbacks:
             callbacks.remove(callback)
-    
+
     def pause_state(self, state_id: int):
         bv = self.bv
         m = bv.session_data.mui_cur_m
@@ -137,7 +137,7 @@ class MUIState:
                 if not self.paused_states:
                     m._busy_states.remove(-1)
                 m._lock.notify_all()
-    
+
     def kill_state(self, state_id: int):
         bv = self.bv
         m = bv.session_data.mui_cur_m
@@ -149,7 +149,6 @@ class MUIState:
                     m._busy_states.remove(-1)
             else:
                 self._register_state_callback(state_id, self.state_kill_hook)
-
 
 
 def highlight_instr(bv: BinaryView, addr: int, color: HighlightStandardColor) -> None:


### PR DESCRIPTION
Closes https://github.com/trailofbits/ManticoreUI/issues/69.

Summary of changes:
1. Refactor of state pause code. More generic API that allows `MUIState` to add callbacks to states based on `state_id`. The callbacks can be removed at runtime unlike manticore hooks.
2. Added `Kill` option to kill states
3. Small quality of life changes to make state list a bit more friendly for right-clicking