### PR TITLE
Fix breaking changes from Binary Ninja 3.1

### DIFF
--- a/mui/manticore_native_runner.py
+++ b/mui/manticore_native_runner.py
@@ -198,7 +198,7 @@ class ManticoreNativeRunner(BackgroundTaskThread):
             h_addr = bv.symbols["__elf_header"][0].address
             h_type = bv.types["Elf64_Header"]
             header = TypedDataAccessor(h_type, h_addr, bv, Endianness.LittleEndian)
-            if header["type"].value == 3:  # ET_DYN
+            if int(header["type"].value) == 3:  # ET_DYN
                 addr_off = BASE_DYN_ADDR
             else:
                 addr_off = 0
@@ -206,7 +206,7 @@ class ManticoreNativeRunner(BackgroundTaskThread):
             h_addr = bv.symbols["__elf_header"][0].address
             h_type = bv.types["Elf32_Header"]
             header = TypedDataAccessor(h_type, h_addr, bv, Endianness.LittleEndian)
-            if header["type"].value == 3:  # ET_DYN
+            if int(header["type"].value) == 3:  # ET_DYN
                 addr_off = BASE_DYN_ADDR_32
             else:
                 addr_off = 0


### PR DESCRIPTION
Something changed in binja that changed the behaviour of the code we use to check for whether a binary is PIE-enabled.

pre 3.1
```py
h_addr = bv.symbols["__elf_header"][0].address
h_type = bv.types["Elf64_Header"]
header = TypedDataAccessor(h_type, h_addr, bv, Endianness.LittleEndian)
header["type"].value

>>> 3
```

3.1
```py
h_addr = bv.symbols["__elf_header"][0].address
h_type = bv.types["Elf64_Header"]
header = TypedDataAccessor(h_type, h_addr, bv, Endianness.LittleEndian)
header["type"].value

>>> <ET_DYN = 0x3>
```

This fix should allow the code to work on both versions.