### PR TITLE
[Ghidra] Edit Hook and Jump to Address via HookList

### DIFF
--- a/plugins/ghidra/MUI/src/main/java/mui/MUIHookCodeDialogLauncher.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIHookCodeDialogLauncher.java
@@ -1,0 +1,56 @@
+package mui;
+
+import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+import ghidra.program.model.address.Address;
+import muicore.MUICore.Hook.HookType;
+
+public class MUIHookCodeDialogLauncher {
+
+	static final String DEFAULT_CUSTOM_FUNCTION =
+		"global m, addr\ndef hook(state):\n    pass\nm.hook(addr)(hook)";
+	static final String DEFAULT_GLOBAL_FUNCTION =
+		"global m\ndef hook(state):\n    pass\nm.hook(None)(hook)";
+
+	public static void showCreateCustom(Address address) {
+		JTextArea textArea = new JTextArea(DEFAULT_CUSTOM_FUNCTION);
+		int result = JOptionPane.showConfirmDialog(null, new JScrollPane(textArea),
+			"Create Custom Hook at " + address.toString(),
+			JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+		if (result == JOptionPane.OK_OPTION) {
+			MUIPlugin.setup.setupHookList.addHook(new MUIHookUserObject(HookType.CUSTOM,
+				address, textArea.getText()));
+		}
+	}
+
+	public static void showCreateGlobal() {
+		JTextArea textArea = new JTextArea(DEFAULT_GLOBAL_FUNCTION);
+		int result = JOptionPane.showConfirmDialog(null, new JScrollPane(textArea),
+			"Create Global Hook",
+			JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+		if (result == JOptionPane.OK_OPTION) {
+			MUIPlugin.setup.setupHookList
+					.addHook(new MUIHookUserObject(HookType.GLOBAL, textArea.getText()));
+		}
+	}
+
+	public static void showEdit(MUIHookUserObject hookObject) {
+		switch (hookObject.type) {
+			case CUSTOM:
+			case GLOBAL:
+				JTextArea textArea = new JTextArea(hookObject.func_text);
+				int result = JOptionPane.showConfirmDialog(null, new JScrollPane(textArea),
+					hookObject.type == HookType.CUSTOM
+							? "Edit Custom Hook at " + hookObject.address.toString()
+							: "Edit Global Hook",
+					JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+				if (result == JOptionPane.OK_OPTION) {
+					hookObject.func_text = textArea.getText();
+				}
+			default:
+				break;
+		}
+	}
+}

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIHookListComponent.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIHookListComponent.java
@@ -2,7 +2,6 @@ package mui;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.event.MouseListener;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,6 +18,7 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
 
+import ghidra.app.services.GoToService;
 import muicore.MUICore.Hook;
 import muicore.MUICore.Hook.HookType;
 
@@ -128,6 +128,20 @@ public class MUIHookListComponent extends JPanel {
 							hookListPopupMenu.show(hookListTree, e.getX(), e.getY());
 						}
 					}
+				}
+				else if (e.getClickCount() == 2 && SwingUtilities.isLeftMouseButton(e)) {
+					TreePath path = hookListTree.getClosestPathForLocation(e.getX(), e.getY());
+					if (path != null) {
+						DefaultMutableTreeNode node =
+							(DefaultMutableTreeNode) path.getLastPathComponent();
+						if (node.getUserObject() instanceof MUIHookUserObject &&
+							((MUIHookUserObject) node.getUserObject()).type != HookType.GLOBAL) {
+							GoToService goToService =
+								MUIPlugin.pluginTool.getService(GoToService.class);
+							goToService.goTo(((MUIHookUserObject) node.getUserObject()).address);
+						}
+					}
+
 				}
 			}
 		});

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIHookListComponent.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIHookListComponent.java
@@ -72,9 +72,7 @@ public class MUIHookListComponent extends JPanel {
 		hookListView.setMinimumSize(new Dimension(0, 0));
 		hookListTree.setPreferredSize(new Dimension(900, 100));
 
-		hookListPopupMenu = new JPopupMenu();
-
-		hookListPopupMenu.add(new JMenuItem(new AbstractAction("Delete Hook") {
+		JMenuItem deleteOption = new JMenuItem(new AbstractAction("Delete Hook") {
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -92,7 +90,18 @@ public class MUIHookListComponent extends JPanel {
 				}
 			}
 
-		}));
+		});
+
+		JMenuItem editOption = new JMenuItem(new AbstractAction("Edit Hook Function Text") {
+
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				if (rightClickedHook != null) {
+					MUIHookCodeDialogLauncher.showEdit(rightClickedHook);
+				}
+			}
+
+		});
 
 		hookListTree.addMouseListener(new MouseInputAdapter() {
 			@Override
@@ -104,6 +113,18 @@ public class MUIHookListComponent extends JPanel {
 							(DefaultMutableTreeNode) path.getLastPathComponent();
 						if (node.getUserObject() instanceof MUIHookUserObject) {
 							rightClickedHook = (MUIHookUserObject) node.getUserObject();
+							hookListPopupMenu = new JPopupMenu();
+							switch (rightClickedHook.type) {
+								case CUSTOM:
+								case GLOBAL:
+									hookListPopupMenu.add(editOption);
+								case FIND:
+								case AVOID:
+									hookListPopupMenu.add(deleteOption);
+									break;
+								default:
+									break;
+							}
 							hookListPopupMenu.show(hookListTree, e.getX(), e.getY());
 						}
 					}

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIHookUserObject.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIHookUserObject.java
@@ -47,6 +47,10 @@ public class MUIHookUserObject {
 				break;
 		}
 		return b.build();
+	}
 
+	@Override
+	public String toString() {
+		return name;
 	}
 }

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIPlugin.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIPlugin.java
@@ -110,16 +110,7 @@ public class MUIPlugin extends ProgramPlugin {
 
 			@Override
 			public void actionPerformed(ActionContext context) {
-				JTextArea textArea =
-					new JTextArea("global m\ndef hook(state):\n    pass\nm.hook(None)(hook)");
-				JScrollPane scrollPane = new JScrollPane(textArea);
-				int result = JOptionPane.showConfirmDialog(null, scrollPane, "Create Global Hook",
-					JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
-				if (result == JOptionPane.OK_OPTION) {
-					String func_text = textArea.getText();
-					setup.setupHookList
-							.addHook(new MUIHookUserObject(HookType.GLOBAL, func_text));
-				}
+				MUIHookCodeDialogLauncher.showCreateGlobal();
 			}
 
 		};

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIPlugin.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIPlugin.java
@@ -65,12 +65,16 @@ public class MUIPlugin extends ProgramPlugin {
 	private DockingAction showStateList;
 	private DockingAction showCreateGlobalHookDialog;
 
+	public static PluginTool pluginTool;
+
 	/**
 	 * The main extension constructor, initializes the plugin's components and sets up the "MUI" MenuBar tab.
 	 * @throws Exception 
 	 */
 	public MUIPlugin(PluginTool tool) throws Exception {
 		super(tool, true, true);
+
+		pluginTool = tool;
 
 		startMUICoreServer();
 		initMUICoreStubs();

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIPopupMenu.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIPopupMenu.java
@@ -122,18 +122,7 @@ public class MUIPopupMenu extends ListingContextAction {
 			new ListingContextAction("Add Custom Hook at Instruction", "MUI") {
 				@Override
 				protected void actionPerformed(ListingActionContext context) {
-					Address selectedAddr = context.getLocation().getAddress();
-					JTextArea textArea = new JTextArea(
-						"global m, addr\ndef hook(state):\n    pass\nm.hook(addr)(hook)");
-					JScrollPane scrollPane = new JScrollPane(textArea);
-					int result = JOptionPane.showConfirmDialog(null, scrollPane,
-						"Create Custom Hook at " + selectedAddr.toString(),
-						JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
-					if (result == JOptionPane.OK_OPTION) {
-						String func_text = textArea.getText();
-						MUIPlugin.setup.setupHookList.addHook(new MUIHookUserObject(HookType.CUSTOM,
-							selectedAddr, func_text));
-					}
+					MUIHookCodeDialogLauncher.showCreateCustom(context.getLocation().getAddress());
 				}
 			};
 		addCustomHookAtInstruction.setPopupMenuData(new MenuData(new String[] {


### PR DESCRIPTION
This PR adds 2 main features:
- Right-clicking on custom/global hooks in the hook list now shows an additional option to edit the hook, which launches the code editor and allows you to edit the hook's function code
- Double-clicking custom/find/avoid hooks in the hook list with jump to that address in the Listing component

Also, 1 minor change:
- hook list now shows hook names (addresses for find/avoid/custom, timestamp for global)

Also, 1 bit of refactoring:
- the Custom/Global Hook Code Editor Dialog is now delegated to a class of its own