### PR TITLE
[Ghidra] Color addresses with custom hooks blue

### DIFF
--- a/plugins/ghidra/MUI/src/main/java/mui/MUIHookAddressColorizer.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIHookAddressColorizer.java
@@ -1,0 +1,49 @@
+package mui;
+
+import java.awt.Color;
+
+import ghidra.app.plugin.core.colorizer.ColorizingService;
+import ghidra.program.model.address.Address;
+import muicore.MUICore.Hook.HookType;
+
+public class MUIHookAddressColorizer {
+
+	/**
+	 * Sets color in the Listing component for the specified address.
+	 * @param address The address to set color of in the Disassembly Listing.
+	 * @param hookType The HookType of the hook at the address being colorized. 
+	 */
+	public static void setColor(Address address, HookType hookType) {
+		ColorizingService service = MUIPlugin.pluginTool.getService(ColorizingService.class);
+		int tid = MUIPlugin.program.startTransaction("setColor");
+		Color toSet = Color.BLUE;
+		switch (hookType) {
+			case FIND:
+				toSet = Color.GREEN;
+				break;
+			case AVOID:
+				toSet = Color.RED;
+				break;
+			case CUSTOM:
+				toSet = new Color(120, 150, 255);
+				break;
+			default:
+				break;
+		}
+
+		service.setBackgroundColor(address, address, toSet);
+		MUIPlugin.program.endTransaction(tid, true);
+	}
+
+	/**
+	 * Clears color from the Listing component for the specified address.
+	 * @param address The address to clear color from.
+	 */
+	public static void clearColor(Address address) {
+		ColorizingService service = MUIPlugin.pluginTool.getService(ColorizingService.class);
+		int tid = MUIPlugin.program.startTransaction("unsetColor");
+		service.clearBackgroundColor(address, address);
+		MUIPlugin.program.endTransaction(tid, true);
+	}
+
+}

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIHookCodeDialogLauncher.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIHookCodeDialogLauncher.java
@@ -1,0 +1,56 @@
+package mui;
+
+import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+import ghidra.program.model.address.Address;
+import muicore.MUICore.Hook.HookType;
+
+public class MUIHookCodeDialogLauncher {
+
+	static final String DEFAULT_CUSTOM_FUNCTION =
+		"global m, addr\ndef hook(state):\n    pass\nm.hook(addr)(hook)";
+	static final String DEFAULT_GLOBAL_FUNCTION =
+		"global m\ndef hook(state):\n    pass\nm.hook(None)(hook)";
+
+	public static void showCreateCustom(Address address) {
+		JTextArea textArea = new JTextArea(DEFAULT_CUSTOM_FUNCTION);
+		int result = JOptionPane.showConfirmDialog(null, new JScrollPane(textArea),
+			"Create Custom Hook at " + address.toString(),
+			JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+		if (result == JOptionPane.OK_OPTION) {
+			MUIPlugin.setup.setupHookList.addHook(new MUIHookUserObject(HookType.CUSTOM,
+				address, textArea.getText()));
+		}
+	}
+
+	public static void showCreateGlobal() {
+		JTextArea textArea = new JTextArea(DEFAULT_GLOBAL_FUNCTION);
+		int result = JOptionPane.showConfirmDialog(null, new JScrollPane(textArea),
+			"Create Global Hook",
+			JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+		if (result == JOptionPane.OK_OPTION) {
+			MUIPlugin.setup.setupHookList
+					.addHook(new MUIHookUserObject(HookType.GLOBAL, textArea.getText()));
+		}
+	}
+
+	public static void showEdit(MUIHookUserObject hookObject) {
+		switch (hookObject.type) {
+			case CUSTOM:
+			case GLOBAL:
+				JTextArea textArea = new JTextArea(hookObject.func_text);
+				int result = JOptionPane.showConfirmDialog(null, new JScrollPane(textArea),
+					hookObject.type == HookType.CUSTOM
+							? "Edit Custom Hook at " + hookObject.address.toString()
+							: "Edit Global Hook",
+					JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+				if (result == JOptionPane.OK_OPTION) {
+					hookObject.func_text = textArea.getText();
+				}
+			default:
+				break;
+		}
+	}
+}

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIHookListComponent.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIHookListComponent.java
@@ -80,8 +80,8 @@ public class MUIHookListComponent extends JPanel {
 					switch (rightClickedHook.type) {
 						case FIND:
 						case AVOID:
-							MUIPlugin.popup.unsetColor(rightClickedHook.address);
 						case CUSTOM:
+							MUIHookAddressColorizer.clearColor(rightClickedHook.address);
 						case GLOBAL:
 							removeHookIfExists(rightClickedHook.name, rightClickedHook.type);
 						default:

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIHookListComponent.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIHookListComponent.java
@@ -2,7 +2,6 @@ package mui;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.event.MouseListener;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,6 +18,7 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
 
+import ghidra.app.services.GoToService;
 import muicore.MUICore.Hook;
 import muicore.MUICore.Hook.HookType;
 
@@ -128,6 +128,20 @@ public class MUIHookListComponent extends JPanel {
 							hookListPopupMenu.show(hookListTree, e.getX(), e.getY());
 						}
 					}
+				}
+				else if (e.getClickCount() == 2 && SwingUtilities.isLeftMouseButton(e)) {
+					TreePath path = hookListTree.getClosestPathForLocation(e.getX(), e.getY());
+					if (path != null) {
+						DefaultMutableTreeNode node =
+							(DefaultMutableTreeNode) path.getLastPathComponent();
+						if (node.getUserObject() instanceof MUIHookUserObject &&
+							((MUIHookUserObject) node.getUserObject()).type != HookType.GLOBAL) {
+							GoToService goToService =
+								MUIPlugin.pluginTool.getService(GoToService.class);
+							goToService.goTo(((MUIHookUserObject) node.getUserObject()).address);
+						}
+					}
+
 				}
 			}
 		});

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIHookListComponent.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIHookListComponent.java
@@ -72,9 +72,7 @@ public class MUIHookListComponent extends JPanel {
 		hookListView.setMinimumSize(new Dimension(0, 0));
 		hookListTree.setPreferredSize(new Dimension(900, 100));
 
-		hookListPopupMenu = new JPopupMenu();
-
-		hookListPopupMenu.add(new JMenuItem(new AbstractAction("Delete Hook") {
+		JMenuItem deleteOption = new JMenuItem(new AbstractAction("Delete Hook") {
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -92,7 +90,18 @@ public class MUIHookListComponent extends JPanel {
 				}
 			}
 
-		}));
+		});
+
+		JMenuItem editOption = new JMenuItem(new AbstractAction("Edit Hook Function Text") {
+
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				if (rightClickedHook != null) {
+					MUIHookCodeDialogLauncher.showEdit(rightClickedHook);
+				}
+			}
+
+		});
 
 		hookListTree.addMouseListener(new MouseInputAdapter() {
 			@Override
@@ -104,6 +113,18 @@ public class MUIHookListComponent extends JPanel {
 							(DefaultMutableTreeNode) path.getLastPathComponent();
 						if (node.getUserObject() instanceof MUIHookUserObject) {
 							rightClickedHook = (MUIHookUserObject) node.getUserObject();
+							hookListPopupMenu = new JPopupMenu();
+							switch (rightClickedHook.type) {
+								case CUSTOM:
+								case GLOBAL:
+									hookListPopupMenu.add(editOption);
+								case FIND:
+								case AVOID:
+									hookListPopupMenu.add(deleteOption);
+									break;
+								default:
+									break;
+							}
 							hookListPopupMenu.show(hookListTree, e.getX(), e.getY());
 						}
 					}

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIHookUserObject.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIHookUserObject.java
@@ -47,6 +47,10 @@ public class MUIHookUserObject {
 				break;
 		}
 		return b.build();
+	}
 
+	@Override
+	public String toString() {
+		return name;
 	}
 }

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIPlugin.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIPlugin.java
@@ -110,16 +110,7 @@ public class MUIPlugin extends ProgramPlugin {
 
 			@Override
 			public void actionPerformed(ActionContext context) {
-				JTextArea textArea =
-					new JTextArea("global m\ndef hook(state):\n    pass\nm.hook(None)(hook)");
-				JScrollPane scrollPane = new JScrollPane(textArea);
-				int result = JOptionPane.showConfirmDialog(null, scrollPane, "Create Global Hook",
-					JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
-				if (result == JOptionPane.OK_OPTION) {
-					String func_text = textArea.getText();
-					setup.setupHookList
-							.addHook(new MUIHookUserObject(HookType.GLOBAL, func_text));
-				}
+				MUIHookCodeDialogLauncher.showCreateGlobal();
 			}
 
 		};

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIPlugin.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIPlugin.java
@@ -65,12 +65,16 @@ public class MUIPlugin extends ProgramPlugin {
 	private DockingAction showStateList;
 	private DockingAction showCreateGlobalHookDialog;
 
+	public static PluginTool pluginTool;
+
 	/**
 	 * The main extension constructor, initializes the plugin's components and sets up the "MUI" MenuBar tab.
 	 * @throws Exception 
 	 */
 	public MUIPlugin(PluginTool tool) throws Exception {
 		super(tool, true, true);
+
+		pluginTool = tool;
 
 		startMUICoreServer();
 		initMUICoreStubs();

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIPlugin.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIPlugin.java
@@ -66,6 +66,7 @@ public class MUIPlugin extends ProgramPlugin {
 	private DockingAction showCreateGlobalHookDialog;
 
 	public static PluginTool pluginTool;
+	public static Program program;
 
 	/**
 	 * The main extension constructor, initializes the plugin's components and sets up the "MUI" MenuBar tab.
@@ -184,7 +185,7 @@ public class MUIPlugin extends ProgramPlugin {
 
 	@Override
 	protected void programActivated(Program p) {
-		setup.setProgram(p);
-		popup.setProgram(p);
+		program = p;
+		setup.setProgramPath(p);
 	}
 }

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIPopupMenu.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIPopupMenu.java
@@ -122,18 +122,7 @@ public class MUIPopupMenu extends ListingContextAction {
 			new ListingContextAction("Add Custom Hook at Instruction", "MUI") {
 				@Override
 				protected void actionPerformed(ListingActionContext context) {
-					Address selectedAddr = context.getLocation().getAddress();
-					JTextArea textArea = new JTextArea(
-						"global m, addr\ndef hook(state):\n    pass\nm.hook(addr)(hook)");
-					JScrollPane scrollPane = new JScrollPane(textArea);
-					int result = JOptionPane.showConfirmDialog(null, scrollPane,
-						"Create Custom Hook at " + selectedAddr.toString(),
-						JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
-					if (result == JOptionPane.OK_OPTION) {
-						String func_text = textArea.getText();
-						MUIPlugin.setup.setupHookList.addHook(new MUIHookUserObject(HookType.CUSTOM,
-							selectedAddr, func_text));
-					}
+					MUIHookCodeDialogLauncher.showCreateCustom(context.getLocation().getAddress());
 				}
 			};
 		addCustomHookAtInstruction.setPopupMenuData(new MenuData(new String[] {

--- a/plugins/ghidra/MUI/src/main/java/mui/MUIPopupMenu.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUIPopupMenu.java
@@ -21,37 +21,12 @@ import ghidra.program.model.address.Address;
  */
 public class MUIPopupMenu extends ListingContextAction {
 
-	private static Program program;
 	public static PluginTool pluginTool;
 
 	public MUIPopupMenu(PluginTool tool, String name) {
 		super(name, name);
 		pluginTool = tool;
 		setupMenu();
-	}
-
-	/**
-	 * Clears color from the Listing component for the specified address.
-	 * @param address The address to clear color from.
-	 */
-	public static void unsetColor(Address address) {
-		ColorizingService service = pluginTool.getService(ColorizingService.class);
-		int tid = program.startTransaction("unsetColor");
-		service.clearBackgroundColor(address, address);
-		program.endTransaction(tid, true);
-	}
-
-	/**
-	 * Sets color in the Listing component for the specified address.
-	 * @param address The address to clear color from.
-	 * @param color The color to set for the address in the Listing component.
-	 */
-	public static void setColor(Address address, Color color) {
-		ColorizingService service = pluginTool.getService(ColorizingService.class);
-		int tid = program.startTransaction("setColor");
-		service.setBackgroundColor(address, address, color);
-		program.endTransaction(tid, true);
-
 	}
 
 	/**
@@ -71,12 +46,12 @@ public class MUIPopupMenu extends ListingContextAction {
 
 					if (MUIPlugin.setup.setupHookList.removeHookIfExists(selectedAddr.toString(),
 						HookType.FIND)) {
-						unsetColor(selectedAddr);
+						MUIHookAddressColorizer.clearColor(selectedAddr);
 					}
 					else {
 						MUIPlugin.setup.setupHookList.addHook(
 							new MUIHookUserObject(HookType.FIND, selectedAddr, null));
-						setColor(selectedAddr, Color.GREEN);
+						MUIHookAddressColorizer.setColor(selectedAddr, HookType.FIND);
 					}
 
 				}
@@ -100,12 +75,12 @@ public class MUIPopupMenu extends ListingContextAction {
 
 					if (MUIPlugin.setup.setupHookList.removeHookIfExists(selectedAddr.toString(),
 						HookType.AVOID)) {
-						unsetColor(selectedAddr);
+						MUIHookAddressColorizer.clearColor(selectedAddr);
 					}
 					else {
 						MUIPlugin.setup.setupHookList.addHook(
 							new MUIHookUserObject(HookType.AVOID, selectedAddr, null));
-						setColor(selectedAddr, Color.RED);
+						MUIHookAddressColorizer.setColor(selectedAddr, HookType.AVOID);
 					}
 
 				}
@@ -122,7 +97,9 @@ public class MUIPopupMenu extends ListingContextAction {
 			new ListingContextAction("Add Custom Hook at Instruction", "MUI") {
 				@Override
 				protected void actionPerformed(ListingActionContext context) {
-					MUIHookCodeDialogLauncher.showCreateCustom(context.getLocation().getAddress());
+					Address selectedAddr = context.getLocation().getAddress();
+					MUIHookCodeDialogLauncher.showCreateCustom(selectedAddr);
+					MUIHookAddressColorizer.setColor(selectedAddr, HookType.CUSTOM);
 				}
 			};
 		addCustomHookAtInstruction.setPopupMenuData(new MenuData(new String[] {
@@ -131,15 +108,6 @@ public class MUIPopupMenu extends ListingContextAction {
 		}));
 
 		pluginTool.addAction(addCustomHookAtInstruction);
-	}
-
-	/** 
-	 * Called once the binary being analyzed in Ghidra has been activated.
-	 * @param p the binary being analyzed in Ghidra
-	 * @see MUIPlugin#programActivated(Program)
-	 */
-	public void setProgram(Program p) {
-		program = p;
 	}
 
 }

--- a/plugins/ghidra/MUI/src/main/java/mui/MUISetupProvider.java
+++ b/plugins/ghidra/MUI/src/main/java/mui/MUISetupProvider.java
@@ -4,9 +4,7 @@ import docking.*;
 import ghidra.framework.plugintool.ComponentProviderAdapter;
 import ghidra.framework.plugintool.PluginTool;
 import ghidra.program.model.listing.Program;
-import muicore.MUICore.Hook;
 import muicore.MUICore.NativeArguments;
-import muicore.MUICore.Hook.HookType;
 
 import java.awt.*;
 import java.awt.event.*;
@@ -23,8 +21,6 @@ import javax.swing.*;
  * Provides the "MUI Setup" component used to set the arguments for and run Manticore.
  */
 public class MUISetupProvider extends ComponentProviderAdapter {
-
-	private Program program;
 
 	private JPanel mainPanel;
 	private String programPath;
@@ -274,9 +270,8 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 	 * @param p the binary being analyzed in Ghidra
 	 * @see MUIPlugin#programActivated(Program)
 	 */
-	public void setProgram(Program p) {
-		program = p;
-		programPath = program.getExecutablePath();
+	public void setProgramPath(Program p) {
+		programPath = p.getExecutablePath();
 	}
 
 	@Override


### PR DESCRIPTION
Quick PR, fixes https://github.com/trailofbits/ManticoreUI/issues/80, took the opportunity to refactor some of the disassembly-highlighting code (with a new MUIHookAddressColorizer class) and make the current `program` a static attribute of MUIPlugin which makes more sense

I can't seem to find RGB values for Binja's HighlightStandardColors so made my best effort to match this blue (since default Colors.BLUE would be too dark)

quick gif showing the colors:
![24-6-1](https://user-images.githubusercontent.com/29654756/175553469-17f486e4-4e1f-46be-9d5b-6e564d241372.gif)



Technically can be merged directly but should probably depend on https://github.com/trailofbits/ManticoreUI/pull/77 being merged (this branch is branched off `fresh-hooklist-changes`)