### PR TITLE
[Server] Add explicit field presence

### DIFF
--- a/server/muicore/MUICore.proto
+++ b/server/muicore/MUICore.proto
@@ -25,7 +25,7 @@ message MUIMessageList{
 message MUIState {
     int32 state_id = 3;
     uint64 pc = 10;
-    int32 parent_id = 28;
+    optional int32 parent_id = 28;
     repeated int32 children_ids = 29;
 }
 
@@ -54,9 +54,9 @@ message Hook {
         GLOBAL = 3;
     }
 
-    uint64 address = 26;
+    optional uint64 address = 26;
     HookType type = 27;
-    string func_text = 31;
+    optional string func_text = 31;
 }
 
 message NativeArguments {
@@ -64,21 +64,21 @@ message NativeArguments {
     repeated string binary_args = 16;    
     repeated string envp = 17;
     repeated string symbolic_files = 18;
-    string concrete_start = 19;
-    string stdin_size = 20;
-    string additional_mcore_args = 21;
-    optional uint64 emulate_until = 22;
+    optional string concrete_start = 19;
+    optional string stdin_size = 20;
+    optional string additional_mcore_args = 21;
     repeated Hook hooks = 30;
+    optional uint64 emulate_until = 32;
 }
 
 message EVMArguments {
     string contract_path = 12;
     string contract_name = 13;
     string solc_bin = 14;
-    string tx_limit = 22;
-    string tx_account = 23;
+    optional string tx_limit = 22;
+    optional string tx_account = 23;
     repeated string detectors_to_exclude = 24;
-    string additional_flags = 25;
+    optional string additional_flags = 25;
 }
 
 message ManticoreRunningStatus {

--- a/server/muicore/MUICore_pb2.py
+++ b/server/muicore/MUICore_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"Q\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\x12\n\n\x02pc\x18\n \x01(\x04\x12\x11\n\tparent_id\x18\x1c \x01(\x05\x12\x14\n\x0c\x63hildren_ids\x18\x1d \x03(\x05\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"\x13\n\x11TerminateResponse\"\x89\x01\n\x04Hook\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12$\n\x04type\x18\x1b \x01(\x0e\x32\x16.muicore.Hook.HookType\x12\x11\n\tfunc_text\x18\x1f \x01(\t\"7\n\x08HookType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\n\n\x06\x43USTOM\x10\x02\x12\n\n\x06GLOBAL\x10\x03\"\xf9\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\x12\x1a\n\remulate_until\x18\x16 \x01(\x04H\x00\x88\x01\x01\x12\x1c\n\x05hooks\x18\x1e \x03(\x0b\x32\r.muicore.HookB\x10\n\x0e_emulate_until\"\xac\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08solc_bin\x18\x0e \x01(\t\x12\x10\n\x08tx_limit\x18\x16 \x01(\t\x12\x12\n\ntx_account\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\t\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\"\x13\n\x11StopServerRequest\"\x14\n\x12StopServerResponse2\x8b\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12G\n\nStopServer\x12\x1a.muicore.StopServerRequest\x1a\x1b.muicore.StopServerResponse\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"d\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\x12\n\n\x02pc\x18\n \x01(\x04\x12\x16\n\tparent_id\x18\x1c \x01(\x05H\x00\x88\x01\x01\x12\x14\n\x0c\x63hildren_ids\x18\x1d \x03(\x05\x42\x0c\n\n_parent_id\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"\x13\n\x11TerminateResponse\"\xad\x01\n\x04Hook\x12\x14\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04H\x00\x88\x01\x01\x12$\n\x04type\x18\x1b \x01(\x0e\x32\x16.muicore.Hook.HookType\x12\x16\n\tfunc_text\x18\x1f \x01(\tH\x01\x88\x01\x01\"7\n\x08HookType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\n\n\x06\x43USTOM\x10\x02\x12\n\n\x06GLOBAL\x10\x03\x42\n\n\x08_addressB\x0c\n\n_func_text\"\xc4\x02\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x1b\n\x0e\x63oncrete_start\x18\x13 \x01(\tH\x00\x88\x01\x01\x12\x17\n\nstdin_size\x18\x14 \x01(\tH\x01\x88\x01\x01\x12\"\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\tH\x02\x88\x01\x01\x12\x1c\n\x05hooks\x18\x1e \x03(\x0b\x32\r.muicore.Hook\x12\x1a\n\remulate_until\x18  \x01(\x04H\x03\x88\x01\x01\x42\x11\n\x0f_concrete_startB\r\n\x0b_stdin_sizeB\x18\n\x16_additional_mcore_argsB\x10\n\x0e_emulate_until\"\xec\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08solc_bin\x18\x0e \x01(\t\x12\x15\n\x08tx_limit\x18\x16 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ntx_account\x18\x17 \x01(\tH\x01\x88\x01\x01\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x1d\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\tH\x02\x88\x01\x01\x42\x0b\n\t_tx_limitB\r\n\x0b_tx_accountB\x13\n\x11_additional_flags\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\"\x13\n\x11StopServerRequest\"\x14\n\x12StopServerResponse2\x8b\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12G\n\nStopServer\x12\x1a.muicore.StopServerRequest\x1a\x1b.muicore.StopServerResponse\"\x00\x62\x06proto3')
 
 
 
@@ -124,27 +124,27 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _MUIMESSAGELIST._serialized_start=68
   _MUIMESSAGELIST._serialized_end=126
   _MUISTATE._serialized_start=128
-  _MUISTATE._serialized_end=209
-  _MUISTATELIST._serialized_start=212
-  _MUISTATELIST._serialized_end=440
-  _MANTICOREINSTANCE._serialized_start=442
-  _MANTICOREINSTANCE._serialized_end=475
-  _TERMINATERESPONSE._serialized_start=477
-  _TERMINATERESPONSE._serialized_end=496
-  _HOOK._serialized_start=499
-  _HOOK._serialized_end=636
-  _HOOK_HOOKTYPE._serialized_start=581
-  _HOOK_HOOKTYPE._serialized_end=636
-  _NATIVEARGUMENTS._serialized_start=639
-  _NATIVEARGUMENTS._serialized_end=888
-  _EVMARGUMENTS._serialized_start=891
-  _EVMARGUMENTS._serialized_end=1063
-  _MANTICORERUNNINGSTATUS._serialized_start=1065
-  _MANTICORERUNNINGSTATUS._serialized_end=1109
-  _STOPSERVERREQUEST._serialized_start=1111
-  _STOPSERVERREQUEST._serialized_end=1130
-  _STOPSERVERRESPONSE._serialized_start=1132
-  _STOPSERVERRESPONSE._serialized_end=1152
-  _MANTICOREUI._serialized_start=1155
-  _MANTICOREUI._serialized_end=1678
+  _MUISTATE._serialized_end=228
+  _MUISTATELIST._serialized_start=231
+  _MUISTATELIST._serialized_end=459
+  _MANTICOREINSTANCE._serialized_start=461
+  _MANTICOREINSTANCE._serialized_end=494
+  _TERMINATERESPONSE._serialized_start=496
+  _TERMINATERESPONSE._serialized_end=515
+  _HOOK._serialized_start=518
+  _HOOK._serialized_end=691
+  _HOOK_HOOKTYPE._serialized_start=610
+  _HOOK_HOOKTYPE._serialized_end=665
+  _NATIVEARGUMENTS._serialized_start=694
+  _NATIVEARGUMENTS._serialized_end=1018
+  _EVMARGUMENTS._serialized_start=1021
+  _EVMARGUMENTS._serialized_end=1257
+  _MANTICORERUNNINGSTATUS._serialized_start=1259
+  _MANTICORERUNNINGSTATUS._serialized_end=1303
+  _STOPSERVERREQUEST._serialized_start=1305
+  _STOPSERVERREQUEST._serialized_end=1324
+  _STOPSERVERRESPONSE._serialized_start=1326
+  _STOPSERVERRESPONSE._serialized_end=1346
+  _MANTICOREUI._serialized_start=1349
+  _MANTICOREUI._serialized_end=1872
 # @@protoc_insertion_point(module_scope)

--- a/server/muicore/MUICore_pb2.pyi
+++ b/server/muicore/MUICore_pb2.pyi
@@ -53,10 +53,12 @@ class MUIState(google.protobuf.message.Message):
         *,
         state_id: builtins.int = ...,
         pc: builtins.int = ...,
-        parent_id: builtins.int = ...,
+        parent_id: typing.Optional[builtins.int] = ...,
         children_ids: typing.Optional[typing.Iterable[builtins.int]] = ...,
         ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["children_ids",b"children_ids","parent_id",b"parent_id","pc",b"pc","state_id",b"state_id"]) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal["_parent_id",b"_parent_id","parent_id",b"parent_id"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal["_parent_id",b"_parent_id","children_ids",b"children_ids","parent_id",b"parent_id","pc",b"pc","state_id",b"state_id"]) -> None: ...
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["_parent_id",b"_parent_id"]) -> typing.Optional[typing_extensions.Literal["parent_id"]]: ...
 global___MUIState = MUIState
 
 class MUIStateList(google.protobuf.message.Message):
@@ -133,11 +135,16 @@ class Hook(google.protobuf.message.Message):
     func_text: typing.Text
     def __init__(self,
         *,
-        address: builtins.int = ...,
+        address: typing.Optional[builtins.int] = ...,
         type: global___Hook.HookType.ValueType = ...,
-        func_text: typing.Text = ...,
+        func_text: typing.Optional[typing.Text] = ...,
         ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["address",b"address","func_text",b"func_text","type",b"type"]) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal["_address",b"_address","_func_text",b"_func_text","address",b"address","func_text",b"func_text"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal["_address",b"_address","_func_text",b"_func_text","address",b"address","func_text",b"func_text","type",b"type"]) -> None: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["_address",b"_address"]) -> typing.Optional[typing_extensions.Literal["address"]]: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["_func_text",b"_func_text"]) -> typing.Optional[typing_extensions.Literal["func_text"]]: ...
 global___Hook = Hook
 
 class NativeArguments(google.protobuf.message.Message):
@@ -149,8 +156,8 @@ class NativeArguments(google.protobuf.message.Message):
     CONCRETE_START_FIELD_NUMBER: builtins.int
     STDIN_SIZE_FIELD_NUMBER: builtins.int
     ADDITIONAL_MCORE_ARGS_FIELD_NUMBER: builtins.int
-    EMULATE_UNTIL_FIELD_NUMBER: builtins.int
     HOOKS_FIELD_NUMBER: builtins.int
+    EMULATE_UNTIL_FIELD_NUMBER: builtins.int
     program_path: typing.Text
     @property
     def binary_args(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
@@ -161,24 +168,31 @@ class NativeArguments(google.protobuf.message.Message):
     concrete_start: typing.Text
     stdin_size: typing.Text
     additional_mcore_args: typing.Text
-    emulate_until: builtins.int
     @property
     def hooks(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___Hook]: ...
+    emulate_until: builtins.int
     def __init__(self,
         *,
         program_path: typing.Text = ...,
         binary_args: typing.Optional[typing.Iterable[typing.Text]] = ...,
         envp: typing.Optional[typing.Iterable[typing.Text]] = ...,
         symbolic_files: typing.Optional[typing.Iterable[typing.Text]] = ...,
-        concrete_start: typing.Text = ...,
-        stdin_size: typing.Text = ...,
-        additional_mcore_args: typing.Text = ...,
-        emulate_until: typing.Optional[builtins.int] = ...,
+        concrete_start: typing.Optional[typing.Text] = ...,
+        stdin_size: typing.Optional[typing.Text] = ...,
+        additional_mcore_args: typing.Optional[typing.Text] = ...,
         hooks: typing.Optional[typing.Iterable[global___Hook]] = ...,
+        emulate_until: typing.Optional[builtins.int] = ...,
         ) -> None: ...
-    def HasField(self, field_name: typing_extensions.Literal["_emulate_until",b"_emulate_until","emulate_until",b"emulate_until"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal["_emulate_until",b"_emulate_until","additional_mcore_args",b"additional_mcore_args","binary_args",b"binary_args","concrete_start",b"concrete_start","emulate_until",b"emulate_until","envp",b"envp","hooks",b"hooks","program_path",b"program_path","stdin_size",b"stdin_size","symbolic_files",b"symbolic_files"]) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal["_additional_mcore_args",b"_additional_mcore_args","_concrete_start",b"_concrete_start","_emulate_until",b"_emulate_until","_stdin_size",b"_stdin_size","additional_mcore_args",b"additional_mcore_args","concrete_start",b"concrete_start","emulate_until",b"emulate_until","stdin_size",b"stdin_size"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal["_additional_mcore_args",b"_additional_mcore_args","_concrete_start",b"_concrete_start","_emulate_until",b"_emulate_until","_stdin_size",b"_stdin_size","additional_mcore_args",b"additional_mcore_args","binary_args",b"binary_args","concrete_start",b"concrete_start","emulate_until",b"emulate_until","envp",b"envp","hooks",b"hooks","program_path",b"program_path","stdin_size",b"stdin_size","symbolic_files",b"symbolic_files"]) -> None: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["_additional_mcore_args",b"_additional_mcore_args"]) -> typing.Optional[typing_extensions.Literal["additional_mcore_args"]]: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["_concrete_start",b"_concrete_start"]) -> typing.Optional[typing_extensions.Literal["concrete_start"]]: ...
+    @typing.overload
     def WhichOneof(self, oneof_group: typing_extensions.Literal["_emulate_until",b"_emulate_until"]) -> typing.Optional[typing_extensions.Literal["emulate_until"]]: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["_stdin_size",b"_stdin_size"]) -> typing.Optional[typing_extensions.Literal["stdin_size"]]: ...
 global___NativeArguments = NativeArguments
 
 class EVMArguments(google.protobuf.message.Message):
@@ -203,12 +217,19 @@ class EVMArguments(google.protobuf.message.Message):
         contract_path: typing.Text = ...,
         contract_name: typing.Text = ...,
         solc_bin: typing.Text = ...,
-        tx_limit: typing.Text = ...,
-        tx_account: typing.Text = ...,
+        tx_limit: typing.Optional[typing.Text] = ...,
+        tx_account: typing.Optional[typing.Text] = ...,
         detectors_to_exclude: typing.Optional[typing.Iterable[typing.Text]] = ...,
-        additional_flags: typing.Text = ...,
+        additional_flags: typing.Optional[typing.Text] = ...,
         ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["additional_flags",b"additional_flags","contract_name",b"contract_name","contract_path",b"contract_path","detectors_to_exclude",b"detectors_to_exclude","solc_bin",b"solc_bin","tx_account",b"tx_account","tx_limit",b"tx_limit"]) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal["_additional_flags",b"_additional_flags","_tx_account",b"_tx_account","_tx_limit",b"_tx_limit","additional_flags",b"additional_flags","tx_account",b"tx_account","tx_limit",b"tx_limit"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal["_additional_flags",b"_additional_flags","_tx_account",b"_tx_account","_tx_limit",b"_tx_limit","additional_flags",b"additional_flags","contract_name",b"contract_name","contract_path",b"contract_path","detectors_to_exclude",b"detectors_to_exclude","solc_bin",b"solc_bin","tx_account",b"tx_account","tx_limit",b"tx_limit"]) -> None: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["_additional_flags",b"_additional_flags"]) -> typing.Optional[typing_extensions.Literal["additional_flags"]]: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["_tx_account",b"_tx_account"]) -> typing.Optional[typing_extensions.Literal["tx_account"]]: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["_tx_limit",b"_tx_limit"]) -> typing.Optional[typing_extensions.Literal["tx_limit"]]: ...
 global___EVMArguments = EVMArguments
 
 class ManticoreRunningStatus(google.protobuf.message.Message):

--- a/server/muicore/mui_server.py
+++ b/server/muicore/mui_server.py
@@ -357,8 +357,6 @@ class MUIServicer(ManticoreUIServicer):
 
             if isinstance(state_desc.parent, int):
                 state_args["parent_id"] = state_desc.parent
-            else:
-                state_args["parent_id"] = -1
 
             state_args["children_ids"] = list(state_desc.children)
 

--- a/server/muicore/mui_server.py
+++ b/server/muicore/mui_server.py
@@ -24,7 +24,7 @@ from manticore.ethereum import ManticoreEVM
 from manticore.native import Manticore
 from manticore.utils.enums import StateLists, StateStatus
 from manticore.utils.helpers import deque
-from manticore.utils.log import CallbackStream, ManticoreContextFilter
+from manticore.utils.log import CallbackStream, ContextFilter
 
 from .evm_utils import setup_detectors_flags
 from .introspect_plugin import MUIIntrospectionPlugin
@@ -90,7 +90,7 @@ class MUIServicer(ManticoreUIServicer):
                 "%(threadName)s %(asctime)s: [%(process)d] %(name)s:%(levelname)s %(message)s"
             )
         )
-        custom_log_handler.addFilter(ManticoreContextFilter())
+        custom_log_handler.addFilter(ContextFilter())
 
         manticore_logger.addHandler(custom_log_handler)
 

--- a/server/muicore/mui_server.py
+++ b/server/muicore/mui_server.py
@@ -24,7 +24,7 @@ from manticore.ethereum import ManticoreEVM
 from manticore.native import Manticore
 from manticore.utils.enums import StateLists, StateStatus
 from manticore.utils.helpers import deque
-from manticore.utils.log import CallbackStream, ContextFilter
+from manticore.utils.log import CallbackStream, ManticoreContextFilter
 
 from .evm_utils import setup_detectors_flags
 from .introspect_plugin import MUIIntrospectionPlugin
@@ -90,7 +90,7 @@ class MUIServicer(ManticoreUIServicer):
                 "%(threadName)s %(asctime)s: [%(process)d] %(name)s:%(levelname)s %(message)s"
             )
         )
-        custom_log_handler.addFilter(ContextFilter())
+        custom_log_handler.addFilter(ManticoreContextFilter())
 
         manticore_logger.addHandler(custom_log_handler)
 


### PR DESCRIPTION
Super quick PR which closes #87

Adds `optional` to fields that may be optional (doesn't apply to `repeated` fields), which improves readability and allows us to use the HasField methods in future instead of relying on a weird default value to indicate an unset field (eg. the state descriptor's `parent_id`, which was changed here)

~~Also, fixes a bug where `ContextFilter` was previously called `ManticoreContextFilter` (I'm a bit confused because this definitely used to work, but the manticore repo git blame suggests that it's been 5 years since the last change)~~ oops it's late and I was using the wrong venv 😪