### PR TITLE
Binja CI excludes binja-integration branch

### DIFF
--- a/.github/workflows/binaryninja-ci.yml
+++ b/.github/workflows/binaryninja-ci.yml
@@ -3,13 +3,13 @@ on:
   push:
     paths:
       - 'plugins/binaryninja/**'
-    branches:
-      - 'master'
+    branches-ignore:
+      - 'binja-integration/master'
   pull_request:
     paths:
       - 'plugins/binaryninja/**'
-    branches:
-      - '*'
+    branches-ignore:
+      - 'binja-integration/master'
 
 jobs:
   ci:

--- a/plugins/binaryninja/requirements-dev.txt
+++ b/plugins/binaryninja/requirements-dev.txt
@@ -1,3 +1,3 @@
 pytest>=6
-black==22.3.0
+black==22.6.0
 mypy==0.910


### PR DESCRIPTION
Fixes the CI issue as described in Slack - binja-integration will no longer affect the cached venv