### PR TITLE
[Binja] Multiple custom hooks can be created at same address 

### DIFF
--- a/.github/workflows/binaryninja-ci.yml
+++ b/.github/workflows/binaryninja-ci.yml
@@ -3,13 +3,13 @@ on:
   push:
     paths:
       - 'plugins/binaryninja/**'
-    branches:
-      - 'master'
+    branches-ignore:
+      - 'binja-migration/master'
   pull_request:
     paths:
       - 'plugins/binaryninja/**'
-    branches:
-      - '*'
+    branches-ignore:
+      - 'binja-migration/master'
 
 jobs:
   ci:

--- a/plugins/binaryninja/mui/dockwidgets/hook_list_widget.py
+++ b/plugins/binaryninja/mui/dockwidgets/hook_list_widget.py
@@ -10,6 +10,7 @@ from binaryninjaui import DockContextHandler, DockHandler, ViewFrame
 from mui.utils import clear_highlight
 import mui.dockwidgets.global_hook_dialog
 import mui.mui
+import mui.hook_manager
 
 
 class HookType(Enum):
@@ -102,7 +103,7 @@ class HookListWidget(QWidget, DockContextHandler):
                 elif parent == self.avoid_hooks:
                     self.mgr.del_avoid_hook(addr)
                 elif parent == self.custom_hooks:
-                    self.mgr.del_custom_hook(name)
+                    self.mgr.del_custom_hook(mui.hook_manager.CustomHookIdentity.from_name(name))
                 elif parent == self.global_hooks:
                     self.mgr.del_global_hook(name)
                 else:

--- a/plugins/binaryninja/mui/dockwidgets/hook_list_widget.py
+++ b/plugins/binaryninja/mui/dockwidgets/hook_list_widget.py
@@ -102,7 +102,7 @@ class HookListWidget(QWidget, DockContextHandler):
                 elif parent == self.avoid_hooks:
                     self.mgr.del_avoid_hook(addr)
                 elif parent == self.custom_hooks:
-                    self.mgr.del_custom_hook(addr)
+                    self.mgr.del_custom_hook(name)
                 elif parent == self.global_hooks:
                     self.mgr.del_global_hook(name)
                 else:
@@ -113,7 +113,7 @@ class HookListWidget(QWidget, DockContextHandler):
 
                 bv = self.bv
                 if parent == self.custom_hooks:
-                    mui.mui.edit_custom_hook(bv, addr)
+                    mui.mui.edit_custom_hook(bv, addr, name)
                 elif parent == self.global_hooks:
                     dialog = mui.dockwidgets.global_hook_dialog.GlobalHookDialog(
                         DockHandler.getActiveDockHandler().parent(), bv, self.mgr

--- a/plugins/binaryninja/mui/dockwidgets/hook_list_widget.py
+++ b/plugins/binaryninja/mui/dockwidgets/hook_list_widget.py
@@ -5,9 +5,10 @@ from PySide6.QtCore import Qt, Slot, QEvent
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QTreeWidgetItem, QTreeWidget, QMenu
 from PySide6.QtGui import QAction
 from binaryninja import BinaryView
-from binaryninjaui import DockContextHandler, ViewFrame
+from binaryninjaui import DockContextHandler, DockHandler, ViewFrame
 
 from mui.utils import clear_highlight
+import mui.dockwidgets.global_hook_dialog
 import mui.mui
 
 
@@ -114,7 +115,10 @@ class HookListWidget(QWidget, DockContextHandler):
                 if parent == self.custom_hooks:
                     mui.mui.edit_custom_hook(bv, addr)
                 elif parent == self.global_hooks:
-                    mui.mui.edit_global_hook(bv)
+                    dialog = mui.dockwidgets.global_hook_dialog.GlobalHookDialog(
+                        DockHandler.getActiveDockHandler().parent(), bv, self.mgr
+                    )
+                    dialog.edit_hook(name)
 
             return True
 

--- a/plugins/binaryninja/mui/hook_manager.py
+++ b/plugins/binaryninja/mui/hook_manager.py
@@ -18,7 +18,7 @@ class NativeHookManager:
     def __init__(self, bv: BinaryView, widget: Optional[HookListWidget] = None):
         self.bv = bv
         self.widget = widget
-        self.custom_hook_ctr = defaultdict(lambda: -1)
+        self.custom_hook_ctr: Dict[int, int] = defaultdict(lambda: -1)
 
     # Add
     def add_find_hook(self, addr: int) -> None:

--- a/plugins/binaryninja/mui/manticore_native_runner.py
+++ b/plugins/binaryninja/mui/manticore_native_runner.py
@@ -41,8 +41,7 @@ class ManticoreNativeRunner(BackgroundTaskThread):
         self.find = [addr + self.addr_off for addr in mgr.list_find_hooks()]
         self.avoid = [addr + self.addr_off for addr in mgr.list_avoid_hooks()]
         self.custom_hooks = [
-            (int(name[:-3], 16) + self.addr_off, func)
-            for name, func in mgr.list_custom_hooks().items()
+            (hook.address + self.addr_off, func) for hook, func in mgr.list_custom_hooks().items()
         ]
         self.global_hooks = list(mgr.list_global_hooks().values())
 

--- a/plugins/binaryninja/mui/manticore_native_runner.py
+++ b/plugins/binaryninja/mui/manticore_native_runner.py
@@ -41,7 +41,8 @@ class ManticoreNativeRunner(BackgroundTaskThread):
         self.find = [addr + self.addr_off for addr in mgr.list_find_hooks()]
         self.avoid = [addr + self.addr_off for addr in mgr.list_avoid_hooks()]
         self.custom_hooks = [
-            (addr + self.addr_off, func) for addr, func in mgr.list_custom_hooks().items()
+            (int(name[:-3], 16) + self.addr_off, func)
+            for name, func in mgr.list_custom_hooks().items()
         ]
         self.global_hooks = list(mgr.list_global_hooks().values())
 

--- a/plugins/binaryninja/mui/mui.py
+++ b/plugins/binaryninja/mui/mui.py
@@ -145,10 +145,10 @@ def edit_custom_hook(bv: BinaryView, addr: int, name=""):
 
     if name and mgr.has_custom_hook(CustomHookIdentity.from_name(name)):
         dialog.set_text(mgr.get_custom_hook(CustomHookIdentity.from_name(name)))
-        hook: CustomHookIdentity = CustomHookIdentity.from_name(name)
+        hook = CustomHookIdentity.from_name(name)
     else:
         mgr.custom_hook_ctr[addr] += 1
-        hook: CustomHookIdentity = CustomHookIdentity(addr, mgr.custom_hook_ctr[addr])
+        hook = CustomHookIdentity(addr, mgr.custom_hook_ctr[addr])
 
     result: QDialog.DialogCode = dialog.exec()
 
@@ -189,7 +189,7 @@ def add_function_model(bv: BinaryView, addr: int) -> None:
             ]
         )
         mgr.custom_hook_ctr[addr] += 1
-        mgr.add_custom_hook(addr, f"{addr:08x}_{mgr.custom_hook_ctr[addr]:02d}", code)
+        mgr.add_custom_hook(CustomHookIdentity(addr, mgr.custom_hook_ctr[addr]), code)
 
 
 def manage_shared_libs(bv) -> None:

--- a/plugins/binaryninja/mui/mui.py
+++ b/plugins/binaryninja/mui/mui.py
@@ -35,7 +35,7 @@ from mui.dockwidgets.global_hook_dialog import GlobalHookDialog
 from mui.dockwidgets.state_graph_widget import StateGraphWidget
 from mui.dockwidgets.state_list_widget import StateListWidget
 from mui.dockwidgets.hook_list_widget import HookListWidget
-from mui.hook_manager import NativeHookManager
+from mui.hook_manager import CustomHookIdentity, NativeHookManager
 from mui.manticore_evm_runner import ManticoreEVMRunner
 from mui.manticore_native_runner import ManticoreNativeRunner
 from mui.notification import UINotification
@@ -143,10 +143,12 @@ def edit_custom_hook(bv: BinaryView, addr: int, name=""):
     dialog = CodeDialog(DockHandler.getActiveDockHandler().parent(), bv)
     mgr: NativeHookManager = bv.session_data.mui_hook_mgr
 
-    if mgr.has_custom_hook(name):
-        dialog.set_text(mgr.get_custom_hook(name))
+    if name and mgr.has_custom_hook(CustomHookIdentity.from_name(name)):
+        dialog.set_text(mgr.get_custom_hook(CustomHookIdentity.from_name(name)))
+        hook: CustomHookIdentity = CustomHookIdentity.from_name(name)
     else:
         mgr.custom_hook_ctr[addr] += 1
+        hook: CustomHookIdentity = CustomHookIdentity(addr, mgr.custom_hook_ctr[addr])
 
     result: QDialog.DialogCode = dialog.exec()
 
@@ -154,10 +156,10 @@ def edit_custom_hook(bv: BinaryView, addr: int, name=""):
         code = dialog.text()
         if not code:
             # delete the hook if empty input is provided
-            if mgr.has_custom_hook(name):
-                mgr.del_custom_hook(name)
+            if name and mgr.has_custom_hook(hook):
+                mgr.del_custom_hook(hook)
         else:
-            mgr.add_custom_hook(addr, f"{addr:08x}_{mgr.custom_hook_ctr[addr]:02d}", code)
+            mgr.add_custom_hook(hook, code)
 
 
 def edit_global_hook(bv: BinaryView):

--- a/plugins/binaryninja/mui/native_plugin.py
+++ b/plugins/binaryninja/mui/native_plugin.py
@@ -19,7 +19,9 @@ class RebaseHooksPlugin(Plugin):
         # Hooks
         self.find = mgr.list_find_hooks()
         self.avoid = mgr.list_avoid_hooks()
-        self.custom_hooks = [(addr, func) for addr, func in mgr.list_custom_hooks().items()]
+        self.custom_hooks = [
+            (int(name[:-3], 16), func) for name, func in mgr.list_custom_hooks().items()
+        ]
         self.global_hooks = list(mgr.list_global_hooks().values())
 
     def on_register(self):

--- a/plugins/binaryninja/mui/native_plugin.py
+++ b/plugins/binaryninja/mui/native_plugin.py
@@ -19,9 +19,7 @@ class RebaseHooksPlugin(Plugin):
         # Hooks
         self.find = mgr.list_find_hooks()
         self.avoid = mgr.list_avoid_hooks()
-        self.custom_hooks = [
-            (int(name[:-3], 16), func) for name, func in mgr.list_custom_hooks().items()
-        ]
+        self.custom_hooks = [(hook.address, func) for hook, func in mgr.list_custom_hooks().items()]
         self.global_hooks = list(mgr.list_global_hooks().values())
 
     def on_register(self):

--- a/plugins/binaryninja/mui/notification.py
+++ b/plugins/binaryninja/mui/notification.py
@@ -38,8 +38,8 @@ class UINotification(UIContextNotification):
             highlight_instr(bv, addr, HighlightStandardColor.GreenHighlightColor)
         for addr in mgr.list_avoid_hooks():
             highlight_instr(bv, addr, HighlightStandardColor.RedHighlightColor)
-        for addr in mgr.list_custom_hooks():
-            highlight_instr(bv, addr, HighlightStandardColor.BlueHighlightColor)
+        for name in mgr.list_custom_hooks():
+            highlight_instr(bv, int(name[:-3], 16), HighlightStandardColor.BlueHighlightColor)
 
         # restore shared libraries
         settings = Settings()

--- a/plugins/binaryninja/mui/notification.py
+++ b/plugins/binaryninja/mui/notification.py
@@ -38,8 +38,8 @@ class UINotification(UIContextNotification):
             highlight_instr(bv, addr, HighlightStandardColor.GreenHighlightColor)
         for addr in mgr.list_avoid_hooks():
             highlight_instr(bv, addr, HighlightStandardColor.RedHighlightColor)
-        for name in mgr.list_custom_hooks():
-            highlight_instr(bv, int(name[:-3], 16), HighlightStandardColor.BlueHighlightColor)
+        for hook in mgr.list_custom_hooks():
+            highlight_instr(bv, hook.address, HighlightStandardColor.BlueHighlightColor)
 
         # restore shared libraries
         settings = Settings()

--- a/plugins/binaryninja/mui/settings.py
+++ b/plugins/binaryninja/mui/settings.py
@@ -148,7 +148,7 @@ class MUISettings:
             "custom": (
                 {
                     "title": "Custom Hooks",
-                    "description": "Addresses and python code for custom hooks",
+                    "description": "Names and python code for custom hooks",
                     "type": "string",
                     "default": json.dumps({}),
                 },

--- a/plugins/binaryninja/requirements-dev.txt
+++ b/plugins/binaryninja/requirements-dev.txt
@@ -1,3 +1,3 @@
 pytest>=6
-black==22.3.0
+black==22.6.0
 mypy==0.910

--- a/plugins/binaryninja/tests/test_hook_manager.py
+++ b/plugins/binaryninja/tests/test_hook_manager.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from mui.hook_manager import NativeHookManager
+from mui.hook_manager import NativeHookManager, CustomHookIdentity
 from binaryninja import open_view
 
 
@@ -29,11 +29,11 @@ class HookManagerTest(unittest.TestCase):
 
     def test_add_custom(self) -> None:
         mgr = self.mgr
-        name = f"{self.MAIN}_00"
-        mgr.add_custom_hook(self.MAIN, name, "# custom hook code")
-        self.assertTrue(mgr.has_custom_hook(name))
-        self.assertEqual(mgr.get_custom_hook(name), "# custom hook code")
-        self.assertEqual(mgr.list_custom_hooks(), {name: "# custom hook code"})
+        hook = CustomHookIdentity(self.MAIN, 0)
+        mgr.add_custom_hook(hook, "# custom hook code")
+        self.assertTrue(mgr.has_custom_hook(hook))
+        self.assertEqual(mgr.get_custom_hook(hook), "# custom hook code")
+        self.assertEqual(mgr.list_custom_hooks(), {hook: "# custom hook code"})
 
     def test_add_global(self) -> None:
         mgr = self.mgr
@@ -59,11 +59,11 @@ class HookManagerTest(unittest.TestCase):
 
     def test_del_custom(self) -> None:
         mgr = self.mgr
-        name = f"{self.MAIN}_00"
-        mgr.add_custom_hook(self.MAIN, name, "# custom hook code")
-        mgr.del_custom_hook(name)
-        self.assertFalse(mgr.has_custom_hook(name))
-        self.assertEqual(mgr.get_custom_hook(name), "")
+        hook = CustomHookIdentity(self.MAIN, 0)
+        mgr.add_custom_hook(hook, "# custom hook code")
+        mgr.del_custom_hook(hook)
+        self.assertFalse(mgr.has_custom_hook(hook))
+        self.assertEqual(mgr.get_custom_hook(hook), "")
         self.assertEqual(mgr.list_custom_hooks(), {})
 
     def test_del_global(self) -> None:
@@ -74,6 +74,18 @@ class HookManagerTest(unittest.TestCase):
         self.assertFalse(mgr.has_global_hook(name))
         self.assertEqual(mgr.get_global_hook(name), "")
         self.assertEqual(mgr.list_global_hooks(), {})
+
+    def test_custom_hook_identity(self) -> None:
+        hook = CustomHookIdentity(self.MAIN, 0)
+        name = f"{self.MAIN:08x}_00"
+        self.assertEqual(hook.to_name(), name)
+        self.assertEqual(hook, CustomHookIdentity.from_name(name))
+
+        mgr = self.mgr
+        mgr.add_custom_hook(hook, "# custom hook code")
+        self.assertEqual(
+            mgr.get_custom_hook(CustomHookIdentity.from_name(name)), "# custom hook code"
+        )
 
 
 if __name__ == "__main__":

--- a/plugins/binaryninja/tests/test_hook_manager.py
+++ b/plugins/binaryninja/tests/test_hook_manager.py
@@ -29,10 +29,11 @@ class HookManagerTest(unittest.TestCase):
 
     def test_add_custom(self) -> None:
         mgr = self.mgr
-        mgr.add_custom_hook(self.MAIN, "# custom hook code")
-        self.assertTrue(mgr.has_custom_hook(self.MAIN))
-        self.assertEqual(mgr.get_custom_hook(self.MAIN), "# custom hook code")
-        self.assertEqual(mgr.list_custom_hooks(), {self.MAIN: "# custom hook code"})
+        name = f"{self.MAIN}_00"
+        mgr.add_custom_hook(self.MAIN, name, "# custom hook code")
+        self.assertTrue(mgr.has_custom_hook(name))
+        self.assertEqual(mgr.get_custom_hook(name), "# custom hook code")
+        self.assertEqual(mgr.list_custom_hooks(), {name: "# custom hook code"})
 
     def test_add_global(self) -> None:
         mgr = self.mgr
@@ -58,10 +59,11 @@ class HookManagerTest(unittest.TestCase):
 
     def test_del_custom(self) -> None:
         mgr = self.mgr
-        mgr.add_custom_hook(self.MAIN, "# custom hook code")
-        mgr.del_custom_hook(self.MAIN)
-        self.assertFalse(mgr.has_custom_hook(self.MAIN))
-        self.assertEqual(mgr.get_custom_hook(self.MAIN), "")
+        name = f"{self.MAIN}_00"
+        mgr.add_custom_hook(self.MAIN, name, "# custom hook code")
+        mgr.del_custom_hook(name)
+        self.assertFalse(mgr.has_custom_hook(name))
+        self.assertEqual(mgr.get_custom_hook(name), "")
         self.assertEqual(mgr.list_custom_hooks(), {})
 
     def test_del_global(self) -> None:

--- a/plugins/binaryninja/tests/test_native_plugin.py
+++ b/plugins/binaryninja/tests/test_native_plugin.py
@@ -14,7 +14,7 @@ class FakeHookManager:
         filename: str,
         find_hooks: Set[int] = set(),
         avoid_hooks: Set[int] = set(),
-        custom_hooks: Dict[int, str] = {},
+        custom_hooks: Dict[str, str] = {},
         global_hooks: Dict[str, str] = {},
     ):
         self.bv = MagicMock()
@@ -30,7 +30,7 @@ class FakeHookManager:
     def list_avoid_hooks(self) -> Set[int]:
         return self.avoid_hooks
 
-    def list_custom_hooks(self) -> Dict[int, str]:
+    def list_custom_hooks(self) -> Dict[str, str]:
         return self.custom_hooks
 
     def list_global_hooks(self) -> Dict[str, str]:
@@ -103,7 +103,8 @@ class RebaseHooksTest(unittest.TestCase):
         m.hook(self.YES)(self.find_f)
 
         mgr = cast(
-            NativeHookManager, FakeHookManager(self.LIB_PATH, custom_hooks={self.FOO: custom_code})
+            NativeHookManager,
+            FakeHookManager(self.LIB_PATH, custom_hooks={f"{self.FOO}_00": custom_code}),
         )
         m.register_plugin(RebaseHooksPlugin(mgr, self.find_f, self.avoid_f))
         m.run()

--- a/plugins/binaryninja/tests/test_persistence.py
+++ b/plugins/binaryninja/tests/test_persistence.py
@@ -13,7 +13,7 @@ class HookPersistenceTest(unittest.TestCase):
             mgr.load_existing_hooks()
             self.assertEqual(mgr.list_find_hooks(), set([0x401152]))
             self.assertEqual(mgr.list_avoid_hooks(), set([0x401153]))
-            self.assertEqual(mgr.list_custom_hooks(), {0x40114D: "# custom hook code"})
+            self.assertEqual(mgr.list_custom_hooks(), {"0x40114D": "# custom hook code"})
             self.assertEqual(mgr.list_global_hooks(), {"global_00": "# global hook code"})
 
 


### PR DESCRIPTION
Closes #83

- Custom hooks are now identified by `name` though the address can be easily retrieved by `int(name[:-3], 16)`
- Name is just address_XX where XX denotes the id of the hook created at that address, similar to the numbering system for Global Hooks
- Additionally, right-clicking on a custom or global hook in the Hook List shows an Edit option which allows you to directly edit the hook code (mimics implementation in https://github.com/trailofbits/ManticoreUI/pull/77)