### PR TITLE
[Server] Support manual state control (Pause/Kill)

### DIFF
--- a/server/muicore/MUICore.proto
+++ b/server/muicore/MUICore.proto
@@ -10,6 +10,7 @@ service ManticoreUI {
     rpc GetMessageList(ManticoreInstance) returns (MUIMessageList) {}
     rpc CheckManticoreRunning(ManticoreInstance) returns (ManticoreRunningStatus) {}
     rpc StopServer(StopServerRequest) returns (StopServerResponse) {}
+    rpc ControlState(ControlStateRequest) returns (ControlStateResponse) {}
 }
 
 // LogMessage and StateList message types have "MUI" in their names to distinguish them from those in mserialize
@@ -37,6 +38,7 @@ message MUIStateList{
     repeated MUIState forked_states = 6;
     repeated MUIState errored_states = 7;
     repeated MUIState complete_states = 8;
+    repeated MUIState paused_states = 33;
 }
 
 message ManticoreInstance {
@@ -88,3 +90,18 @@ message ManticoreRunningStatus {
 message StopServerRequest {}
 
 message StopServerResponse {}
+
+message ControlStateRequest {
+
+    enum StateAction {
+        RESUME = 0;
+        PAUSE = 1;
+        KILL = 2;
+    }
+
+    int32 state_id = 34;
+    ManticoreInstance manticore_instance = 35;
+    StateAction action = 36;
+}
+
+message ControlStateResponse {}

--- a/server/muicore/MUICore_pb2.py
+++ b/server/muicore/MUICore_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"d\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\x12\n\n\x02pc\x18\n \x01(\x04\x12\x16\n\tparent_id\x18\x1c \x01(\x05H\x00\x88\x01\x01\x12\x14\n\x0c\x63hildren_ids\x18\x1d \x03(\x05\x42\x0c\n\n_parent_id\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"\x13\n\x11TerminateResponse\"\xad\x01\n\x04Hook\x12\x14\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04H\x00\x88\x01\x01\x12$\n\x04type\x18\x1b \x01(\x0e\x32\x16.muicore.Hook.HookType\x12\x16\n\tfunc_text\x18\x1f \x01(\tH\x01\x88\x01\x01\"7\n\x08HookType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\n\n\x06\x43USTOM\x10\x02\x12\n\n\x06GLOBAL\x10\x03\x42\n\n\x08_addressB\x0c\n\n_func_text\"\xc4\x02\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x1b\n\x0e\x63oncrete_start\x18\x13 \x01(\tH\x00\x88\x01\x01\x12\x17\n\nstdin_size\x18\x14 \x01(\tH\x01\x88\x01\x01\x12\"\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\tH\x02\x88\x01\x01\x12\x1c\n\x05hooks\x18\x1e \x03(\x0b\x32\r.muicore.Hook\x12\x1a\n\remulate_until\x18  \x01(\x04H\x03\x88\x01\x01\x42\x11\n\x0f_concrete_startB\r\n\x0b_stdin_sizeB\x18\n\x16_additional_mcore_argsB\x10\n\x0e_emulate_until\"\xec\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08solc_bin\x18\x0e \x01(\t\x12\x15\n\x08tx_limit\x18\x16 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ntx_account\x18\x17 \x01(\tH\x01\x88\x01\x01\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x1d\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\tH\x02\x88\x01\x01\x42\x0b\n\t_tx_limitB\r\n\x0b_tx_accountB\x13\n\x11_additional_flags\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\"\x13\n\x11StopServerRequest\"\x14\n\x12StopServerResponse2\x8b\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12G\n\nStopServer\x12\x1a.muicore.StopServerRequest\x1a\x1b.muicore.StopServerResponse\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"d\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\x12\n\n\x02pc\x18\n \x01(\x04\x12\x16\n\tparent_id\x18\x1c \x01(\x05H\x00\x88\x01\x01\x12\x14\n\x0c\x63hildren_ids\x18\x1d \x03(\x05\x42\x0c\n\n_parent_id\"\x8e\x02\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rpaused_states\x18! \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"\x13\n\x11TerminateResponse\"\xad\x01\n\x04Hook\x12\x14\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04H\x00\x88\x01\x01\x12$\n\x04type\x18\x1b \x01(\x0e\x32\x16.muicore.Hook.HookType\x12\x16\n\tfunc_text\x18\x1f \x01(\tH\x01\x88\x01\x01\"7\n\x08HookType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\n\n\x06\x43USTOM\x10\x02\x12\n\n\x06GLOBAL\x10\x03\x42\n\n\x08_addressB\x0c\n\n_func_text\"\xc4\x02\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x1b\n\x0e\x63oncrete_start\x18\x13 \x01(\tH\x00\x88\x01\x01\x12\x17\n\nstdin_size\x18\x14 \x01(\tH\x01\x88\x01\x01\x12\"\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\tH\x02\x88\x01\x01\x12\x1c\n\x05hooks\x18\x1e \x03(\x0b\x32\r.muicore.Hook\x12\x1a\n\remulate_until\x18  \x01(\x04H\x03\x88\x01\x01\x42\x11\n\x0f_concrete_startB\r\n\x0b_stdin_sizeB\x18\n\x16_additional_mcore_argsB\x10\n\x0e_emulate_until\"\xec\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08solc_bin\x18\x0e \x01(\t\x12\x15\n\x08tx_limit\x18\x16 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ntx_account\x18\x17 \x01(\tH\x01\x88\x01\x01\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x1d\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\tH\x02\x88\x01\x01\x42\x0b\n\t_tx_limitB\r\n\x0b_tx_accountB\x13\n\x11_additional_flags\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\"\x13\n\x11StopServerRequest\"\x14\n\x12StopServerResponse\"\xc9\x01\n\x13\x43ontrolStateRequest\x12\x10\n\x08state_id\x18\" \x01(\x05\x12\x36\n\x12manticore_instance\x18# \x01(\x0b\x32\x1a.muicore.ManticoreInstance\x12\x38\n\x06\x61\x63tion\x18$ \x01(\x0e\x32(.muicore.ControlStateRequest.StateAction\".\n\x0bStateAction\x12\n\n\x06RESUME\x10\x00\x12\t\n\x05PAUSE\x10\x01\x12\x08\n\x04KILL\x10\x02\"\x16\n\x14\x43ontrolStateResponse2\xda\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12G\n\nStopServer\x12\x1a.muicore.StopServerRequest\x1a\x1b.muicore.StopServerResponse\"\x00\x12M\n\x0c\x43ontrolState\x12\x1c.muicore.ControlStateRequest\x1a\x1d.muicore.ControlStateResponse\"\x00\x62\x06proto3')
 
 
 
@@ -30,7 +30,10 @@ _EVMARGUMENTS = DESCRIPTOR.message_types_by_name['EVMArguments']
 _MANTICORERUNNINGSTATUS = DESCRIPTOR.message_types_by_name['ManticoreRunningStatus']
 _STOPSERVERREQUEST = DESCRIPTOR.message_types_by_name['StopServerRequest']
 _STOPSERVERRESPONSE = DESCRIPTOR.message_types_by_name['StopServerResponse']
+_CONTROLSTATEREQUEST = DESCRIPTOR.message_types_by_name['ControlStateRequest']
+_CONTROLSTATERESPONSE = DESCRIPTOR.message_types_by_name['ControlStateResponse']
 _HOOK_HOOKTYPE = _HOOK.enum_types_by_name['HookType']
+_CONTROLSTATEREQUEST_STATEACTION = _CONTROLSTATEREQUEST.enum_types_by_name['StateAction']
 MUILogMessage = _reflection.GeneratedProtocolMessageType('MUILogMessage', (_message.Message,), {
   'DESCRIPTOR' : _MUILOGMESSAGE,
   '__module__' : 'muicore.MUICore_pb2'
@@ -115,6 +118,20 @@ StopServerResponse = _reflection.GeneratedProtocolMessageType('StopServerRespons
   })
 _sym_db.RegisterMessage(StopServerResponse)
 
+ControlStateRequest = _reflection.GeneratedProtocolMessageType('ControlStateRequest', (_message.Message,), {
+  'DESCRIPTOR' : _CONTROLSTATEREQUEST,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.ControlStateRequest)
+  })
+_sym_db.RegisterMessage(ControlStateRequest)
+
+ControlStateResponse = _reflection.GeneratedProtocolMessageType('ControlStateResponse', (_message.Message,), {
+  'DESCRIPTOR' : _CONTROLSTATERESPONSE,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.ControlStateResponse)
+  })
+_sym_db.RegisterMessage(ControlStateResponse)
+
 _MANTICOREUI = DESCRIPTOR.services_by_name['ManticoreUI']
 if _descriptor._USE_C_DESCRIPTORS == False:
 
@@ -126,25 +143,31 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _MUISTATE._serialized_start=128
   _MUISTATE._serialized_end=228
   _MUISTATELIST._serialized_start=231
-  _MUISTATELIST._serialized_end=459
-  _MANTICOREINSTANCE._serialized_start=461
-  _MANTICOREINSTANCE._serialized_end=494
-  _TERMINATERESPONSE._serialized_start=496
-  _TERMINATERESPONSE._serialized_end=515
-  _HOOK._serialized_start=518
-  _HOOK._serialized_end=691
-  _HOOK_HOOKTYPE._serialized_start=610
-  _HOOK_HOOKTYPE._serialized_end=665
-  _NATIVEARGUMENTS._serialized_start=694
-  _NATIVEARGUMENTS._serialized_end=1018
-  _EVMARGUMENTS._serialized_start=1021
-  _EVMARGUMENTS._serialized_end=1257
-  _MANTICORERUNNINGSTATUS._serialized_start=1259
-  _MANTICORERUNNINGSTATUS._serialized_end=1303
-  _STOPSERVERREQUEST._serialized_start=1305
-  _STOPSERVERREQUEST._serialized_end=1324
-  _STOPSERVERRESPONSE._serialized_start=1326
-  _STOPSERVERRESPONSE._serialized_end=1346
-  _MANTICOREUI._serialized_start=1349
-  _MANTICOREUI._serialized_end=1872
+  _MUISTATELIST._serialized_end=501
+  _MANTICOREINSTANCE._serialized_start=503
+  _MANTICOREINSTANCE._serialized_end=536
+  _TERMINATERESPONSE._serialized_start=538
+  _TERMINATERESPONSE._serialized_end=557
+  _HOOK._serialized_start=560
+  _HOOK._serialized_end=733
+  _HOOK_HOOKTYPE._serialized_start=652
+  _HOOK_HOOKTYPE._serialized_end=707
+  _NATIVEARGUMENTS._serialized_start=736
+  _NATIVEARGUMENTS._serialized_end=1060
+  _EVMARGUMENTS._serialized_start=1063
+  _EVMARGUMENTS._serialized_end=1299
+  _MANTICORERUNNINGSTATUS._serialized_start=1301
+  _MANTICORERUNNINGSTATUS._serialized_end=1345
+  _STOPSERVERREQUEST._serialized_start=1347
+  _STOPSERVERREQUEST._serialized_end=1366
+  _STOPSERVERRESPONSE._serialized_start=1368
+  _STOPSERVERRESPONSE._serialized_end=1388
+  _CONTROLSTATEREQUEST._serialized_start=1391
+  _CONTROLSTATEREQUEST._serialized_end=1592
+  _CONTROLSTATEREQUEST_STATEACTION._serialized_start=1546
+  _CONTROLSTATEREQUEST_STATEACTION._serialized_end=1592
+  _CONTROLSTATERESPONSE._serialized_start=1594
+  _CONTROLSTATERESPONSE._serialized_end=1616
+  _MANTICOREUI._serialized_start=1619
+  _MANTICOREUI._serialized_end=2221
 # @@protoc_insertion_point(module_scope)

--- a/server/muicore/MUICore_pb2.pyi
+++ b/server/muicore/MUICore_pb2.pyi
@@ -68,6 +68,7 @@ class MUIStateList(google.protobuf.message.Message):
     FORKED_STATES_FIELD_NUMBER: builtins.int
     ERRORED_STATES_FIELD_NUMBER: builtins.int
     COMPLETE_STATES_FIELD_NUMBER: builtins.int
+    PAUSED_STATES_FIELD_NUMBER: builtins.int
     @property
     def active_states(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___MUIState]:
         """state categories in MUI - based on manticore enums StateStatus and StateList"""
@@ -80,6 +81,8 @@ class MUIStateList(google.protobuf.message.Message):
     def errored_states(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___MUIState]: ...
     @property
     def complete_states(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___MUIState]: ...
+    @property
+    def paused_states(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___MUIState]: ...
     def __init__(self,
         *,
         active_states: typing.Optional[typing.Iterable[global___MUIState]] = ...,
@@ -87,8 +90,9 @@ class MUIStateList(google.protobuf.message.Message):
         forked_states: typing.Optional[typing.Iterable[global___MUIState]] = ...,
         errored_states: typing.Optional[typing.Iterable[global___MUIState]] = ...,
         complete_states: typing.Optional[typing.Iterable[global___MUIState]] = ...,
+        paused_states: typing.Optional[typing.Iterable[global___MUIState]] = ...,
         ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["active_states",b"active_states","complete_states",b"complete_states","errored_states",b"errored_states","forked_states",b"forked_states","waiting_states",b"waiting_states"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["active_states",b"active_states","complete_states",b"complete_states","errored_states",b"errored_states","forked_states",b"forked_states","paused_states",b"paused_states","waiting_states",b"waiting_states"]) -> None: ...
 global___MUIStateList = MUIStateList
 
 class ManticoreInstance(google.protobuf.message.Message):
@@ -254,3 +258,43 @@ class StopServerResponse(google.protobuf.message.Message):
     def __init__(self,
         ) -> None: ...
 global___StopServerResponse = StopServerResponse
+
+class ControlStateRequest(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+    class _StateAction:
+        ValueType = typing.NewType('ValueType', builtins.int)
+        V: typing_extensions.TypeAlias = ValueType
+    class _StateActionEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[ControlStateRequest._StateAction.ValueType], builtins.type):
+        DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
+        RESUME: ControlStateRequest._StateAction.ValueType  # 0
+        PAUSE: ControlStateRequest._StateAction.ValueType  # 1
+        KILL: ControlStateRequest._StateAction.ValueType  # 2
+    class StateAction(_StateAction, metaclass=_StateActionEnumTypeWrapper):
+        pass
+
+    RESUME: ControlStateRequest.StateAction.ValueType  # 0
+    PAUSE: ControlStateRequest.StateAction.ValueType  # 1
+    KILL: ControlStateRequest.StateAction.ValueType  # 2
+
+    STATE_ID_FIELD_NUMBER: builtins.int
+    MANTICORE_INSTANCE_FIELD_NUMBER: builtins.int
+    ACTION_FIELD_NUMBER: builtins.int
+    state_id: builtins.int
+    @property
+    def manticore_instance(self) -> global___ManticoreInstance: ...
+    action: global___ControlStateRequest.StateAction.ValueType
+    def __init__(self,
+        *,
+        state_id: builtins.int = ...,
+        manticore_instance: typing.Optional[global___ManticoreInstance] = ...,
+        action: global___ControlStateRequest.StateAction.ValueType = ...,
+        ) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal["manticore_instance",b"manticore_instance"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal["action",b"action","manticore_instance",b"manticore_instance","state_id",b"state_id"]) -> None: ...
+global___ControlStateRequest = ControlStateRequest
+
+class ControlStateResponse(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+    def __init__(self,
+        ) -> None: ...
+global___ControlStateResponse = ControlStateResponse

--- a/server/muicore/MUICore_pb2_grpc.py
+++ b/server/muicore/MUICore_pb2_grpc.py
@@ -49,6 +49,11 @@ class ManticoreUIStub(object):
                 request_serializer=muicore_dot_MUICore__pb2.StopServerRequest.SerializeToString,
                 response_deserializer=muicore_dot_MUICore__pb2.StopServerResponse.FromString,
                 )
+        self.ControlState = channel.unary_unary(
+                '/muicore.ManticoreUI/ControlState',
+                request_serializer=muicore_dot_MUICore__pb2.ControlStateRequest.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.ControlStateResponse.FromString,
+                )
 
 
 class ManticoreUIServicer(object):
@@ -96,6 +101,12 @@ class ManticoreUIServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def ControlState(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_ManticoreUIServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -133,6 +144,11 @@ def add_ManticoreUIServicer_to_server(servicer, server):
                     servicer.StopServer,
                     request_deserializer=muicore_dot_MUICore__pb2.StopServerRequest.FromString,
                     response_serializer=muicore_dot_MUICore__pb2.StopServerResponse.SerializeToString,
+            ),
+            'ControlState': grpc.unary_unary_rpc_method_handler(
+                    servicer.ControlState,
+                    request_deserializer=muicore_dot_MUICore__pb2.ControlStateRequest.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.ControlStateResponse.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -260,5 +276,22 @@ class ManticoreUI(object):
         return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/StopServer',
             muicore_dot_MUICore__pb2.StopServerRequest.SerializeToString,
             muicore_dot_MUICore__pb2.StopServerResponse.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def ControlState(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/ControlState',
+            muicore_dot_MUICore__pb2.ControlStateRequest.SerializeToString,
+            muicore_dot_MUICore__pb2.ControlStateResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)


### PR DESCRIPTION
First of 3 PRs meant to demonstrate the process of adding a feature to the MUI Plugins - first by implementing Manticore functionality in the MUI Server and then making UI changes on the respective plugin frontends.

This PR adds support for manual state pausing and killing. Closes #85.

Commit messages have been written & rebased to be descriptive, but an overview of what's done here is:

1. Adding a new rpc and modifying an existing rpc request message in the protocol buffer spec (`MUICore.proto`)
2. Generating Python files and stubs with `just generate`
3. Implementing the actual functionality by interacting with the Manticore API in `mui_server.py`
4. Writing new tests