### PR TITLE
Add Documentation

### DIFF
--- a/docs/binaryninja/evm.rst
+++ b/docs/binaryninja/evm.rst
@@ -1,0 +1,30 @@
+EVM
+===
+
+ManticoreUI has some support for the EVM features of Manticore as well.
+EVM features require installation of the ethersplay_ plugin.
+
+Load Contract
+-------------
+
+This command allows you to load a solidity contract and compile it for use with ManticoreUI.
+
+**Usage:** ::
+
+    Open command palette (Cntrl-Shift-P) > MUI - Load Ethereum Contract
+
+
+
+Solve With Manticore
+--------------------
+
+For EVM, using Solve With Manticore will attempt to run through possible transactions to explore full coverage of the contract being tested.
+The results will be shown at the end with a run report.
+
+**Usage:** ::
+
+    Open command palette (Cntrl-Shift-P) > MUI - Solve With Manticore
+
+
+
+.. _ethersplay: https://github.com/crytic/ethersplay

--- a/docs/binaryninja/evm.rst
+++ b/docs/binaryninja/evm.rst
@@ -11,7 +11,7 @@ This command allows you to load a solidity contract and compile it for use with 
 
 **Usage:** ::
 
-    Open command palette (Cntrl-Shift-P) > MUI - Load Ethereum Contract
+    Open command palette (Cntrl-P) > MUI - Load Ethereum Contract
 
 
 
@@ -23,7 +23,7 @@ The results will be shown at the end with a run report.
 
 **Usage:** ::
 
-    Open command palette (Cntrl-Shift-P) > MUI - Solve With Manticore
+    Open command palette (Cntrl-P) > MUI - Solve With Manticore
 
 
 

--- a/docs/binaryninja/function_models.rst
+++ b/docs/binaryninja/function_models.rst
@@ -1,0 +1,36 @@
+Function Models
+===============
+
+Function models are Python implementations of common functions.
+They can be used to override the native implementations to provide performance increases.
+Read more about function models in the manticore documentation `here <Manticore Docs_>`_.
+
+
+When opening a new binary, ManticoreUI will alert you to functions that have function models available for use. ::
+
+    ###################################
+    # MUI Function Model Analysis     #
+    #                                 #
+    # 02 function(s) match:           #
+    # * 0003d400, strlen              #
+    # * 0003dcf0, strcmp              #
+    ###################################
+    -> Use 'Add Function Model' to hook these functions
+
+
+You can double click on the hex addresses listed, or navigate manually to the functions.
+
+**Usage:** ::
+
+    Right click on an instruction > Plugins > MUI > Add Function Model
+
+    OR
+
+    Select instruction > Open command palette (Cntrl-Shift-P) > MUI - Add Function Model
+
+
+Doing the above will create a custom hook at the selected function to invoke the function model override.
+If you wish to customise the custom hook implementing the function model, simply edit it like any other custom hook using the `Hook List`.
+
+
+.. _Manticore Docs: https://manticore.readthedocs.io/en/latest/native.html#function-models

--- a/docs/binaryninja/function_models.rst
+++ b/docs/binaryninja/function_models.rst
@@ -26,7 +26,7 @@ You can double click on the hex addresses listed, or navigate manually to the fu
 
     OR
 
-    Select instruction > Open command palette (Cntrl-Shift-P) > MUI - Add Function Model
+    Select instruction > Open command palette (Cntrl-P) > MUI - Add Function Model
 
 
 Doing the above will create a custom hook at the selected function to invoke the function model override.

--- a/docs/binaryninja/hooks.rst
+++ b/docs/binaryninja/hooks.rst
@@ -18,7 +18,7 @@ Use find hooks to indicate areas of code which you want to reach (e.g. a functio
 
     OR
 
-    Select instruction > Open command palette (Cntrl-Shift-P) > MUI - Find Path to This Instruction
+    Select instruction > Open command palette (Cntrl-P) > MUI - Find Path to This Instruction
 
 Avoid hooks are placed at a specific address of the binary.
 When Manticore executes the instruction at that address, it will abandon the state that executed the instruction and continue executing other active states.
@@ -30,7 +30,7 @@ Use avoid hooks to indicate areas of code which you do not want to reach (e.g. a
 
     OR
 
-    Select instruction > Open command palette (Cntrl-Shift-P) > MUI - Avoid This Instruction
+    Select instruction > Open command palette (Cntrl-P) > MUI - Avoid This Instruction
 
 
 
@@ -47,7 +47,7 @@ Use custom hooks to perform state manipulations, or to log any output necessary 
 
     OR
 
-    Select instruction > Open command palette (Cntrl-Shift-P) > MUI - Add Custom Hook
+    Select instruction > Open command palette (Cntrl-P) > MUI - Add Custom Hook
 
 
 
@@ -61,4 +61,4 @@ These can be useful for detecting certain state conditions and running correspon
 
 **Usage:** ::
 
-    Open command palette (Cntrl-Shift-P) > MUI - Add/Edit Global Hook
+    Open command palette (Cntrl-P) > MUI - Add/Edit Global Hook

--- a/docs/binaryninja/hooks.rst
+++ b/docs/binaryninja/hooks.rst
@@ -1,0 +1,64 @@
+Native Hooks
+============
+
+Hooks are an essential feature for using ManticoreUI with native binaries.
+They allow you to interact with the execution of Manticore through manipulating the state or manticore object.
+
+
+Find/Avoid
+----------
+
+Find hooks are placed at a specific address of the binary.
+When Manticore executes the instruction at that address, it will end the entire run of Manticore and log the solution for any symbolic variables present.
+Use find hooks to indicate areas of code which you want to reach (e.g. a function that indicates a success condition).
+
+**Usage:** ::
+
+    Right click on an instruction > Plugins > MUI > Find Path to This Instruction
+
+    OR
+
+    Select instruction > Open command palette (Cntrl-Shift-P) > MUI - Find Path to This Instruction
+
+Avoid hooks are placed at a specific address of the binary.
+When Manticore executes the instruction at that address, it will abandon the state that executed the instruction and continue executing other active states.
+Use avoid hooks to indicate areas of code which you do not want to reach (e.g. a function that indicates a error condition).
+
+**Usage:** ::
+
+    Right click on an instruction > Plugins > MUI > Avoid This Instruction
+
+    OR
+
+    Select instruction > Open command palette (Cntrl-Shift-P) > MUI - Avoid This Instruction
+
+
+
+Custom Hooks
+------------
+
+Custom hooks are placed at a specific address of the binary.
+When Manticore executes the instruction at that address, it will run the code specified by your custom hook.
+Use custom hooks to perform state manipulations, or to log any output necessary (e.g. using custom hooks to change register values).
+
+**Usage:** ::
+
+    Right click on an instruction > Plugins > MUI > Add Custom Hook
+
+    OR
+
+    Select instruction > Open command palette (Cntrl-Shift-P) > MUI - Add Custom Hook
+
+
+
+Global Hooks
+------------
+
+Global hooks are triggered for *every* instruction executed.
+The hooks will run custom code provided by the user.
+These can be useful for detecting certain state conditions and running corresponding actions.
+
+
+**Usage:** ::
+
+    Open command palette (Cntrl-Shift-P) > MUI - Add/Edit Global Hook

--- a/docs/binaryninja/shared_library.rst
+++ b/docs/binaryninja/shared_library.rst
@@ -1,0 +1,28 @@
+Shared Libraries
+================
+
+ManticoreUI has additional features to support the workflow for setting `hooks <Hooks_>`_ in external libraries.
+
+If you wished to set a custom hook in the `malloc` function in the libc shared library, an example workflow would look like so:
+
+1. Open the `libc.so` in Binary Ninja
+2. Place any necessary hooks through the ManticoreUI interface
+3. Save the project as a `.bndb` somewhere on your system (e.g. `/tmp/libc.bndb`)
+
+Now let's say you want to apply this hook to another binary that dynamically links the libc, `/bin/ls`.
+
+4. Open `/bin/ls` in Binary Ninja
+5. Add the shared library bndb to the MUI project (`libc.bndb`)
+
+**Usage:** ::
+
+    Open command palette (Cntrl-Shift-P) > MUI - Manage Shared Library BNDBs
+
+    Click Add
+
+    Select the bndb path (e.g. `/tmp/libc.bndb`)
+
+6. With this bndb added to your `/bin/ls` MUI project, any subsequent runs of `Solve With Manticore` will dynamically add any hooks from the `/tmp/libc.bndb` project into the current execution space.
+
+
+.. _Hooks: hooks.rst

--- a/docs/binaryninja/shared_library.rst
+++ b/docs/binaryninja/shared_library.rst
@@ -16,7 +16,7 @@ Now let's say you want to apply this hook to another binary that dynamically lin
 
 **Usage:** ::
 
-    Open command palette (Cntrl-Shift-P) > MUI - Manage Shared Library BNDBs
+    Open command palette (Cntrl-P) > MUI - Manage Shared Library BNDBs
 
     Click Add
 

--- a/docs/binaryninja/state_management.rst
+++ b/docs/binaryninja/state_management.rst
@@ -42,7 +42,7 @@ Save Trace
 ----------
 
 This option only works if the `Trace Instructions` option was enabled.
-Only Paused/Forked/Complete/Errored states have these options.
+Only Paused/Forked/Complete/Errored states have this option.
 
 Using Save Trace will prompt you to select a filename to save the trace.
 A DrCov_-compatible save data will be saved into that file.

--- a/docs/binaryninja/state_management.rst
+++ b/docs/binaryninja/state_management.rst
@@ -1,0 +1,54 @@
+State Management
+================
+
+ManticoreUI supports live management of states during an execution of Manticore.
+You can do so by right-clicking states in the `State List` MUI widget.
+A few actions are possible.
+
+
+Pause/Resume
+------------
+
+Only Active/Waiting/Paused states have these options.
+
+Use Pause to temporarily pause states.
+You may then trace such states to understand where they are currently executing.
+You may also wish to kill paused states if you deem them unnecessary.
+
+Use Resume to resume paused states.
+They will resume execution till paused/completed.
+
+
+Kill
+----
+
+Only Active/Waiting/Paused states have this option.
+Killing a state is equivalent to running `state.abandon()` and the state will be terminated forever.
+
+
+Show/Hide Trace
+---------------
+
+This option only works if the `Trace Instructions` option was enabled.
+Only Paused/Forked/Complete/Errored states have these options.
+
+Using Show Trace will highlight your BinaryView at the basic blocks that have been executed.
+Use this to understand where the states have executed.
+
+Using Hide Trace will unhighlight a previously highlighted trace.
+
+
+Save Trace
+----------
+
+This option only works if the `Trace Instructions` option was enabled.
+Only Paused/Forked/Complete/Errored states have these options.
+
+Using Save Trace will prompt you to select a filename to save the trace.
+A DrCov_-compatible save data will be saved into that file.
+
+This can be loaded in other tools like Lighthouse_ or similar trace visualisation tools.
+
+
+.. _DrCov: https://dynamorio.org/page_drcov.html
+.. _Lighthouse: https://github.com/gaasedelen/lighthouse

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -13,7 +13,7 @@ Native Feature Table
 +-------------------------+---------------------------------+-------------------------------+
 | Feature                 | Binary Ninja                    | Ghidra                        |
 +=========================+=================================+===============================+
-| Solve                   | `✔️ <Binja EVM Solve_>`_        | `✔️ <Ghidra EVM Solve_>`_     |
+| Find/Avoid              | `✔️ <Binja Find Avoid_>`_       | `✔️ <Ghidra Find Avoid_>`_    |
 +-------------------------+---------------------------------+-------------------------------+
 | Custom Hooks            | `✔️ <Binja Custom Hooks_>`_     | `✔️ <Ghidra Custom Hooks_>`_  |
 +-------------------------+---------------------------------+-------------------------------+
@@ -59,6 +59,4 @@ EVM Feature Table
 
 .. _Ghidra Multiple Inst: #
 
-
 .. _Binja EVM Solve: binaryninja/evm.rst
-.. _Ghidra EVM Solve: ghidra/evm.rst

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -13,7 +13,7 @@ Native Feature Table
 +-------------------------+---------------------------------+-------------------------------+
 | Feature                 | Binary Ninja                    | Ghidra                        |
 +=========================+=================================+===============================+
-| Find/Avoid              | `✔️ <Binja Find Avoid_>`_       | `✔️ <Ghidra Find Avoid_>`_    |
+| Solve                   | `✔️ <Binja EVM Solve_>`_        | `✔️ <Ghidra EVM Solve_>`_     |
 +-------------------------+---------------------------------+-------------------------------+
 | Custom Hooks            | `✔️ <Binja Custom Hooks_>`_     | `✔️ <Ghidra Custom Hooks_>`_  |
 +-------------------------+---------------------------------+-------------------------------+
@@ -27,10 +27,21 @@ Native Feature Table
 +-------------------------+---------------------------------+-------------------------------+
 | State Tracing           | `✔️ <Binja State Tracing_>`_    |                               |
 +-------------------------+---------------------------------+-------------------------------+
+| Multiple Instances      |                                 | `✔️ <Ghidra Multiple Inst_>`_ |
++-------------------------+---------------------------------+-------------------------------+
+
 
 
 EVM Feature Table
 -----------------
+
++----------+---------------------------+---------+
+| Feature  | Binary Ninja              | Ghidra  |
++==========+===========================+=========+
+| Solve    | `✔️ <Binja EVM Solve_>`_  |         |
++----------+---------------------------+---------+
+
+
 
 .. _Binja Find Avoid: binaryninja/hooks.rst#find-avoid
 .. _Ghidra Find Avoid: ghidra/hooks.rst#find-avoid
@@ -45,3 +56,9 @@ EVM Feature Table
 .. _Binja Shared Lib: binaryninja/shared_library.rst
 .. _Binja State Mgmt: binaryninja/state_management.rst
 .. _Binja State Tracing: binaryninja/state_management.rst#show-hide-trace
+
+.. _Ghidra Multiple Inst: #
+
+
+.. _Binja EVM Solve: binaryninja/evm.rst
+.. _Ghidra EVM Solve: ghidra/evm.rst

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1,0 +1,47 @@
+Features
+========
+
+ManticoreUI has various features to improve the experience of using Manticore.
+
+There is currently a difference in features supported by the Binary Ninja and Ghidra versions of ManticoreUI.
+This is outlined in the tables below:
+
+
+Native Feature Table
+--------------------
+
++-------------------------+---------------------------------+-------------------------------+
+| Feature                 | Binary Ninja                    | Ghidra                        |
++=========================+=================================+===============================+
+| Find/Avoid              | `✔️ <Binja Find Avoid_>`_       | `✔️ <Ghidra Find Avoid_>`_    |
++-------------------------+---------------------------------+-------------------------------+
+| Custom Hooks            | `✔️ <Binja Custom Hooks_>`_     | `✔️ <Ghidra Custom Hooks_>`_  |
++-------------------------+---------------------------------+-------------------------------+
+| Global Hooks            | `✔️ <Binja Global Hooks_>`_     | `✔️ <Ghidra Global Hooks_>`_  |
++-------------------------+---------------------------------+-------------------------------+
+| Function Models         | `✔️ <Binja Function Models_>`_  |                               |
++-------------------------+---------------------------------+-------------------------------+
+| Shared Library Support  | `✔️ <Binja Shared Lib_>`_       |                               |
++-------------------------+---------------------------------+-------------------------------+
+| Live State Management   | `✔️ <Binja State Mgmt_>`_       |                               |
++-------------------------+---------------------------------+-------------------------------+
+| State Tracing           | `✔️ <Binja State Tracing_>`_    |                               |
++-------------------------+---------------------------------+-------------------------------+
+
+
+EVM Feature Table
+-----------------
+
+.. _Binja Find Avoid: binaryninja/hooks.rst#find-avoid
+.. _Ghidra Find Avoid: ghidra/hooks.rst#find-avoid
+
+.. _Binja Custom Hooks: binaryninja/hooks.rst#custom-hooks
+.. _Ghidra Custom Hooks: ghidra/hooks.rst#custom-hooks
+
+.. _Binja Global Hooks: binaryninja/hooks.rst#global-hooks
+.. _Ghidra Global Hooks: ghidra/hooks.rst#global-hooks
+
+.. _Binja Function Models: binaryninja/function_models.rst
+.. _Binja Shared Lib: binaryninja/shared_library.rst
+.. _Binja State Mgmt: binaryninja/state_management.rst
+.. _Binja State Tracing: binaryninja/state_management.rst#show-hide-trace

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -43,8 +43,8 @@ EVM Feature Table
 
 
 
-.. _Binja Find Avoid: binaryninja/hooks.rst#find-avoid
-.. _Ghidra Find Avoid: ghidra/hooks.rst#find-avoid
+.. _Binja Find Avoid: binaryninja/hooks.rst#findavoid
+.. _Ghidra Find Avoid: ghidra/hooks.rst#findavoid
 
 .. _Binja Custom Hooks: binaryninja/hooks.rst#custom-hooks
 .. _Ghidra Custom Hooks: ghidra/hooks.rst#custom-hooks
@@ -55,7 +55,7 @@ EVM Feature Table
 .. _Binja Function Models: binaryninja/function_models.rst
 .. _Binja Shared Lib: binaryninja/shared_library.rst
 .. _Binja State Mgmt: binaryninja/state_management.rst
-.. _Binja State Tracing: binaryninja/state_management.rst#show-hide-trace
+.. _Binja State Tracing: binaryninja/state_management.rst#showhide-trace
 
 .. _Ghidra Multiple Inst: #
 

--- a/docs/ghidra/hooks.rst
+++ b/docs/ghidra/hooks.rst
@@ -1,0 +1,53 @@
+Native Hooks
+============
+
+Hooks are an essential feature for using ManticoreUI with native binaries.
+They allow you to interact with the execution of Manticore through manipulating the state or manticore object.
+
+
+Find/Avoid
+----------
+
+Find hooks are placed at a specific address of the binary.
+When Manticore executes the instruction at that address, it will end the entire run of Manticore and log the solution for any symbolic variables present.
+Use find hooks to indicate areas of code which you want to reach (e.g. a function that indicates a success condition).
+
+**Usage:** ::
+
+    Right click on an instruction > MUI > Toggle Find Instruction
+
+
+Avoid hooks are placed at a specific address of the binary.
+When Manticore executes the instruction at that address, it will abandon the state that executed the instruction and continue executing other active states.
+Use avoid hooks to indicate areas of code which you do not want to reach (e.g. a function that indicates a error condition).
+
+**Usage:** ::
+
+    Right click on an instruction > MUI > Toggle Avoid Instruction
+
+
+
+Custom Hooks
+------------
+
+Custom hooks are placed at a specific address of the binary.
+When Manticore executes the instruction at that address, it will run the code specified by your custom hook.
+Use custom hooks to perform state manipulations, or to log any output necessary (e.g. using custom hooks to change register values).
+
+**Usage:** ::
+
+    Right click on an instruction > MUI > Add Custom Hook at Instruction
+
+
+
+Global Hooks
+------------
+
+Global hooks are triggered for *every* instruction executed.
+The hooks will run custom code provided by the user.
+These can be useful for detecting certain state conditions and running corresponding actions.
+
+
+**Usage:** ::
+
+    (Menu Bar) MUI > Create Global Hook


### PR DESCRIPTION
Adds a new /docs directory containing more detailed documentation on features. This is meant to supplement what we current have in the respective READMEs.

The `features.rst` doc is the central doc that links to all other documentations.