### PR TITLE
[Binja] Add TraceBlockPlugin tests

### DIFF
--- a/plugins/binaryninja/mui/native_plugin.py
+++ b/plugins/binaryninja/mui/native_plugin.py
@@ -132,6 +132,8 @@ class TraceBlockPlugin(Plugin):
         "LJMP",
         "LOOP",
         "LOOPNZ",
+        "SYSCALL",
+        "INT",
     }
 
     def will_run_callback(self, ready_states):

--- a/plugins/binaryninja/tests/test_native_plugin.py
+++ b/plugins/binaryninja/tests/test_native_plugin.py
@@ -154,6 +154,7 @@ class FakeMUIState:
 class TraceBlockTest(unittest.TestCase):
     BIN_PATH = os.path.join(os.path.dirname(__file__), "binaries", "hello_world")
     # Generated with DynamoRIO: `env -i drrun -t drcov -dump_text -- hello_world > /dev/null`
+    # Manticore stdout does not have a tty, piping to /dev/null mimics this
     TRACE = {
         4198400,
         4198416,
@@ -319,7 +320,8 @@ class TraceBlockTest(unittest.TestCase):
         4202912,
         4203138,
     }
-    # Init libc seems to behave differently between manticore and native, ignore blocks from it
+    # __init_libc behaves differently between manticore and native
+    # likely due to different environment variables, ignore blocks from it
     INIT_LIBC = 0x401180
     INIT_LIBC_END = 0x401398
 

--- a/plugins/binaryninja/tests/test_native_plugin.py
+++ b/plugins/binaryninja/tests/test_native_plugin.py
@@ -331,7 +331,7 @@ class TraceBlockTest(unittest.TestCase):
 
         trace = mui_state.state_trace[0]
 
-        diff = trace.difference(self.TRACE)
+        diff = trace.symmetric_difference(self.TRACE)
         diff = set(filter(lambda x: not self.INIT_LIBC <= x < self.INIT_LIBC_END, diff))
         self.assertFalse(diff)
 

--- a/plugins/binaryninja/tests/test_native_plugin.py
+++ b/plugins/binaryninja/tests/test_native_plugin.py
@@ -153,7 +153,7 @@ class FakeMUIState:
 
 class TraceBlockTest(unittest.TestCase):
     BIN_PATH = os.path.join(os.path.dirname(__file__), "binaries", "hello_world")
-    # Generated with DynamoRIO: `env -i drrun -t drcov -dump_text -- hello_world`
+    # Generated with DynamoRIO: `env -i drrun -t drcov -dump_text -- hello_world > /dev/null`
     TRACE = {
         4198400,
         4198416,
@@ -254,6 +254,7 @@ class TraceBlockTest(unittest.TestCase):
         4201241,
         4201255,
         4201271,
+        4201280,
         4201312,
         4201339,
         4201424,
@@ -321,8 +322,6 @@ class TraceBlockTest(unittest.TestCase):
     # Init libc seems to behave differently between manticore and native, ignore blocks from it
     INIT_LIBC = 0x401180
     INIT_LIBC_END = 0x401398
-    # IOCTL for fd={0,1,2} on manticore currently doesn't work
-    IOCTL_SKIP = 0x401B40
 
     def test_trace_block(self) -> None:
         mui_state = cast(MUIState, FakeMUIState())
@@ -331,8 +330,6 @@ class TraceBlockTest(unittest.TestCase):
         m.run()
 
         trace = mui_state.state_trace[0]
-        if self.IOCTL_SKIP in trace:
-            trace.remove(self.IOCTL_SKIP)
 
         diff = trace.difference(self.TRACE)
         diff = set(filter(lambda x: not self.INIT_LIBC <= x < self.INIT_LIBC_END, diff))


### PR DESCRIPTION
Adds tests for `TraceBlockPlugin` which saves a basic-block trace for manticore states.

Fix bug in `TraceBlockPlugin` causing tests to fail.