### PR TITLE
Fix bug in CI, run CI when workflow is modified

### DIFF
--- a/.github/workflows/binaryninja-ci.yml
+++ b/.github/workflows/binaryninja-ci.yml
@@ -13,12 +13,7 @@ on:
 
 jobs:
   ci:
-    strategy:
-      fail-fast: false
-      matrix:
-        python: [3.8]
-        os: ubuntu-20.04
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -27,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.8
 
       - name: 'Install tools'
         run: |

--- a/.github/workflows/binaryninja-ci.yml
+++ b/.github/workflows/binaryninja-ci.yml
@@ -3,11 +3,13 @@ on:
   pull_request:
     paths:
       - 'plugins/binaryninja/**'
+      - '.github/workflows/binaryninja-ci.yml'
     branches-ignore:
       - 'binja-migration/master'
   push:
     paths:
       - 'plugins/binaryninja/**'
+      - '.github/workflows/binaryninja-ci.yml'
     branches-ignore:
       - 'binja-migration/master'
 

--- a/.github/workflows/binaryninja-ci.yml
+++ b/.github/workflows/binaryninja-ci.yml
@@ -1,11 +1,11 @@
 name: binaryninja-ci
 on:
-  push:
+  pull_request:
     paths:
       - 'plugins/binaryninja/**'
     branches-ignore:
       - 'binja-migration/master'
-  pull_request:
+  push:
     paths:
       - 'plugins/binaryninja/**'
     branches-ignore:
@@ -16,9 +16,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
-          fetch-depth: 1
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ghidra-ci.yml
+++ b/.github/workflows/ghidra-ci.yml
@@ -3,11 +3,13 @@ on:
   pull_request:
     paths:
       - 'plugins/ghidra/**'
+      - '.github/workflows/ghidra-ci.yml'
     branches:
       - '*'
   push:
     paths:
       - 'plugins/ghidra/**'
+      - '.github/workflows/ghidra-ci.yml'
     branches:
       - '*'
 

--- a/.github/workflows/ghidra-ci.yml
+++ b/.github/workflows/ghidra-ci.yml
@@ -12,7 +12,7 @@ on:
       - '*'
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -12,7 +12,7 @@ on:
       - '*'
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -3,11 +3,13 @@ on:
   pull_request:
     paths:
       - 'server/**'
+      - '.github/workflows/server-ci.yml'
     branches:
       - '*'
   push:
     paths:
       - 'server/**'
+      - '.github/workflows/server-ci.yml'
     branches:
       - '*'
 


### PR DESCRIPTION
There is a bug in CI causing the binja workflow not to run (the Actions tab shows a bunch of CI startup failures)

The fix is that the `ubuntu-20.04` in the binja workflow matrix needs to be in square brackets. That said, there is no longer a need for a matrix, so this PR fixes that bug and allows binja CI to run again and simplifies the workflow.

Additionally, we used to have to make dummy commits in the respective plugin/server directories to get CI to run if we were only editing the workflow. This PR also makes CI run if the workflow itself has been modified.