### PR TITLE
[Binja] Fix plugin manager install

### DIFF
--- a/plugins/binaryninja/binjastub/__init__.py
+++ b/plugins/binaryninja/binjastub/__init__.py
@@ -1,8 +1,9 @@
 import os
-import z3
 import sys
-from pathlib import Path
 from distutils.dir_util import copy_tree
+from pathlib import Path
+
+import z3
 
 DIR = os.path.dirname(__file__)
 

--- a/plugins/binaryninja/binjastub/__init__.py
+++ b/plugins/binaryninja/binjastub/__init__.py
@@ -1,10 +1,14 @@
 import os
 import z3
+import sys
 from pathlib import Path
 
 # Hack to include z3 path for virtualenv installs
 bin_path = Path(z3.__file__).parent.parent / "bin"
 if bin_path.exists():
     os.environ["PATH"] = str(bin_path) + ":" + os.environ.get("PATH", "")
+
+# Add parent directory to sys.path
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 import mui

--- a/plugins/binaryninja/binjastub/__init__.py
+++ b/plugins/binaryninja/binjastub/__init__.py
@@ -2,6 +2,7 @@ import os
 import z3
 import sys
 from pathlib import Path
+from distutils.dir_util import copy_tree
 
 # Hack to include z3 path for virtualenv installs
 bin_path = Path(z3.__file__).parent.parent / "bin"
@@ -10,5 +11,8 @@ if bin_path.exists():
 
 # Add parent directory to sys.path
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+# Copy common files
+copy_tree("../../common", "../mui/common_resources", update=1)
 
 import mui

--- a/plugins/binaryninja/binjastub/__init__.py
+++ b/plugins/binaryninja/binjastub/__init__.py
@@ -4,15 +4,17 @@ import sys
 from pathlib import Path
 from distutils.dir_util import copy_tree
 
+DIR = os.path.dirname(__file__)
+
 # Hack to include z3 path for virtualenv installs
 bin_path = Path(z3.__file__).parent.parent / "bin"
 if bin_path.exists():
     os.environ["PATH"] = str(bin_path) + ":" + os.environ.get("PATH", "")
 
 # Add parent directory to sys.path
-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(os.path.join(DIR, ".."))
 
 # Copy common files
-copy_tree("../../common", "../mui/common_resources", update=1)
+copy_tree(os.path.join(DIR, "../../common"), os.path.join(DIR, "../mui/common_resources"), update=1)
 
 import mui


### PR DESCRIPTION
Cleans up the code to make sure we can install using the plugin manager.

To test:

1. (shell) `mkdir ~/.binaryninja/repositories/test`
2. (optional) setup virtualenv settings in Binary Ninja if need be
3. Run the following inside Binary Ninja python interpreter

```py
mgr = RepositoryManager()
mgr.add_repository("https://raw.githubusercontent.com/lordidiot/community-plugins/master/plugins.json", "test")
mgr.check_for_updates()
```

4. `Manage Plugins` in Binary Ninja, search for `ManticoreUI` in the page
5. Click `Install` followed by `Enable`
