### PR TITLE
[Binja] Cleanup requirements.txt

### DIFF
--- a/plugins/binaryninja/binjastub/requirements.txt
+++ b/plugins/binaryninja/binjastub/requirements.txt
@@ -1,2 +1,3 @@
+# Latest commit on Manticore `master` branch as of July 28, 2022
 manticore[native] @ git+https://github.com/trailofbits/manticore.git@04cc68dbf164af976df23e3a435207aa8fcb246d
 pygments>=2.7.0,<2.9.0

--- a/plugins/binaryninja/binjastub/requirements.txt
+++ b/plugins/binaryninja/binjastub/requirements.txt
@@ -1,6 +1,2 @@
-git+https://github.com/trailofbits/manticore.git@2918710d468c5c2225ac64c0b550a8c1c672b332
+manticore[native] @ git+https://github.com/trailofbits/manticore.git@04cc68dbf164af976df23e3a435207aa8fcb246d
 pygments>=2.7.0,<2.9.0
-crytic-compile>=0.2.0
-capstone @ git+https://github.com/aquynh/capstone.git@1766485c0c32419e9a17d6ad31f9e218ef4f018f#subdirectory=bindings/python
-pyelftools
-unicorn==1.0.2


### PR DESCRIPTION
Two changes:
1. Bumps manticore version to use https://github.com/trailofbits/manticore/commit/04cc68dbf164af976df23e3a435207aa8fcb246d
2. Specifies `[native]` optional dependency for manticore so that we don't have to manually add native dependencies